### PR TITLE
Conserta bug de encoding e adiciona tratamento à alguns erros

### DIFF
--- a/crawlers/base_spider.py
+++ b/crawlers/base_spider.py
@@ -143,8 +143,8 @@ class BaseSpider(scrapy.Spider):
             )
 
             file_mode = "w+"
-            body = cleaner.clean_html(response.body.decode('ascii', errors='ignore'))
-            # encoding = "utf-8-sig"
+            body = cleaner.clean_html(
+                response.body.decode('ascii', errors='ignore'))
 
         hsh = crawling_utils.hash(response.url)
 
@@ -165,7 +165,6 @@ class BaseSpider(scrapy.Spider):
         with open(
             file=f"{folder}/{hsh}.{file_format}",
             mode=file_mode,
-            # encoding=encoding,
         ) as f:
             f.write(body)
 
@@ -182,19 +181,19 @@ class BaseSpider(scrapy.Spider):
         # you may need the failure's type
         self.logger.error(repr(failure))
 
-        #if isinstance(failure.value, HttpError):
+        # if isinstance(failure.value, HttpError):
         if failure.check(HttpError):
             # you can get the response
             response = failure.value.response
             self.logger.error('HttpError on %s', response.url)
 
-        #elif isinstance(failure.value, DNSLookupError):
+        # elif isinstance(failure.value, DNSLookupError):
         elif failure.check(DNSLookupError):
             # this is the original request
             request = failure.request
             self.logger.error('DNSLookupError on %s', request.url)
 
-        #elif isinstance(failure.value, TimeoutError):
+        # elif isinstance(failure.value, TimeoutError):
         elif failure.check(TimeoutError):
             request = failure.request
             self.logger.error('TimeoutError on %s', request.url)

--- a/crawlers/base_spider.py
+++ b/crawlers/base_spider.py
@@ -144,7 +144,7 @@ class BaseSpider(scrapy.Spider):
 
             file_mode = "w+"
             body = cleaner.clean_html(
-                response.body.decode('ascii', errors='ignore'))
+                response.body.decode('utf-8', errors='ignore'))
 
         hsh = crawling_utils.hash(response.url)
 
@@ -181,19 +181,16 @@ class BaseSpider(scrapy.Spider):
         # you may need the failure's type
         self.logger.error(repr(failure))
 
-        # if isinstance(failure.value, HttpError):
         if failure.check(HttpError):
             # you can get the response
             response = failure.value.response
             self.logger.error('HttpError on %s', response.url)
 
-        # elif isinstance(failure.value, DNSLookupError):
         elif failure.check(DNSLookupError):
             # this is the original request
             request = failure.request
             self.logger.error('DNSLookupError on %s', request.url)
 
-        # elif isinstance(failure.value, TimeoutError):
         elif failure.check(TimeoutError):
             request = failure.request
             self.logger.error('TimeoutError on %s', request.url)

--- a/crawlers/base_spider.py
+++ b/crawlers/base_spider.py
@@ -17,6 +17,9 @@ import parsing_html
 from lxml.html.clean import Cleaner
 import codecs
 
+from scrapy.spidermiddlewares.httperror import HttpError
+from twisted.internet.error import DNSLookupError
+from twisted.internet.error import TimeoutError
 
 class BaseSpider(scrapy.Spider):
     name = 'base_spider'
@@ -140,8 +143,8 @@ class BaseSpider(scrapy.Spider):
             )
 
             file_mode = "w+"
-            body = cleaner.clean_html(response.body.decode('utf-8-sig'))
-            encoding = "utf-8-sig"
+            body = cleaner.clean_html(response.body.decode('ascii', errors='ignore'))
+            # encoding = "utf-8-sig"
 
         hsh = crawling_utils.hash(response.url)
 
@@ -162,7 +165,7 @@ class BaseSpider(scrapy.Spider):
         with open(
             file=f"{folder}/{hsh}.{file_format}",
             mode=file_mode,
-            encoding=encoding,
+            # encoding=encoding,
         ) as f:
             f.write(body)
 
@@ -172,3 +175,26 @@ class BaseSpider(scrapy.Spider):
         """Stores html and adds its description to file_description file."""
         self.store_raw(
             response, file_format="html", binary=False, save_at="raw_pages")
+
+    def errback_httpbin(self, failure):
+        # log all errback failures,
+        # in case you want to do something special for some errors,
+        # you may need the failure's type
+        self.logger.error(repr(failure))
+
+        #if isinstance(failure.value, HttpError):
+        if failure.check(HttpError):
+            # you can get the response
+            response = failure.value.response
+            self.logger.error('HttpError on %s', response.url)
+
+        #elif isinstance(failure.value, DNSLookupError):
+        elif failure.check(DNSLookupError):
+            # this is the original request
+            request = failure.request
+            self.logger.error('DNSLookupError on %s', request.url)
+
+        #elif isinstance(failure.value, TimeoutError):
+        elif failure.check(TimeoutError):
+            request = failure.request
+            self.logger.error('TimeoutError on %s', request.url)

--- a/crawlers/static_page.py
+++ b/crawlers/static_page.py
@@ -26,7 +26,8 @@ class StaticPageSpider(BaseSpider):
         for url in urls:
             yield scrapy.Request(
                 url=url, callback=self.parse,
-                meta={"referer": "start_requests"}
+                meta={"referer": "start_requests"},
+                errback=self.errback_httpbin
             )
 
     def convert_allow_extesions(self):
@@ -108,7 +109,8 @@ class StaticPageSpider(BaseSpider):
                 for url in self.extract_links(response):
                     yield scrapy.Request(
                         url=url, callback=self.parse,
-                        meta={"referer": response.url}
+                        meta={"referer": response.url},
+                        errback=self.errback_httpbin
                     )
         else:
             self.store_raw(response)

--- a/src/parsing_html/parsing_html/content.py
+++ b/src/parsing_html/parsing_html/content.py
@@ -25,7 +25,7 @@ def clean_html(html_file, is_string):
         f = html_file
         soup = BeautifulSoup(f, 'html.parser')
     else:
-        f = open(html_file, encoding="utf-8-sig")
+        f = open(html_file, "r", errors='ignore')
         soup = BeautifulSoup(f, 'html.parser')
         f.close()
 
@@ -136,7 +136,7 @@ def html_detect_content(
 
     # Check if html file exists. Will raise exception if not.
     if not is_string:
-        with open(html_file, "r") as f:
+        with open(html_file, "r", errors='ignore') as f:
             pass
 
     try:


### PR DESCRIPTION
1. Resolvido problema de encoding do arquivo ".html" (pelo menos pra página de São Lourenço). Acredito ser um tratamento genérico o suficiente pra resolver outros possíveis problemas também;
2. Adicionei uma função que captura erros no twister e nas requisições do spider. Fiz isso pois quando um coletor descobria um link de uma página que não responde ou tentava baixar um arquivo muito grande isso causa timeouts até o limite de vezes e fecha o spider. Agora o spider só loga que aconteceu o erro e continua a coleta. Essa informação também vai aparecer nos stats finais escritos no log quando a coleta acabar. É uma solução que encontrei no stack overflow.

Close #202 