### PR TITLE
Issue 217 - Corrigir testes de captcha para incluir mock no Pytesseract

### DIFF
--- a/tests/test_captcha_solver/test_image_solver.py
+++ b/tests/test_captcha_solver/test_image_solver.py
@@ -1,5 +1,6 @@
 import unittest
 import numpy as np
+from unittest.mock import patch
 
 from captcha_solver.image_solver import ImageSolver
 from PIL import Image, ImageDraw, ImageFont
@@ -9,26 +10,28 @@ class ImageSolverTest(unittest.TestCase):
     def setUp(self):
         self.solver = ImageSolver()
 
-    def test_solver(self):
+    @patch("captcha_solver.image_solver.pytesseract")
+    def test_solver(self, pytesseract_mock):
         """
             Test main method in the class, which the user access
         """
-
         self.assertRaises(Exception, self.solver.solve, **{"image":1, "source":""})
         self.assertRaises(Exception, self.solver.solve)
+        pytesseract_mock.image_to_string.return_value = "test_string"
 
         img = Image.new('RGB', (100,100), color = (73, 109, 137))
-        self.assertEqual(self.solver.solve(img), "")
+        self.assertEqual(self.solver.solve(img), "test_string")
 
-    def test_ocr(self):
+    @patch("captcha_solver.image_solver.pytesseract")
+    def test_ocr(self, pytesseract_mock):
         """
             Test the OCR method in the class
             this method is based in the Googles' Tesseract
             optical character recognition
         """
-
+        pytesseract_mock.image_to_string.return_value = "test_string"
         img = Image.new('RGB', (100,100), color = (73, 109, 137))
-        self.assertEqual(self.solver._ocr(img), "")
+        self.assertEqual(self.solver._ocr(img), "test_string")
 
     def test_preprocess(self):
         """


### PR DESCRIPTION
Para evitar instalar dependência a mais nos testes (tesseract), esse PR "mocka" as chamadas ao Pytesseract.