### PR TITLE
Issue #230 - Passagem incorreta de parametros

### DIFF
--- a/crawlers/base_spider.py
+++ b/crawlers/base_spider.py
@@ -96,7 +96,6 @@ class BaseSpider(scrapy.Spider):
 
         return self.stop_flag
 
-
     def extract_and_store_csv(self, response, content):
         """
         Try to extract a json/csv from response data.

--- a/crawlers/base_spider.py
+++ b/crawlers/base_spider.py
@@ -97,7 +97,7 @@ class BaseSpider(scrapy.Spider):
         return self.stop_flag
 
 
-    def extract_and_store_csv(self, response, content, save_csv):
+    def extract_and_store_csv(self, response, content):
         """
         Try to extract a json/csv from response data.
         """
@@ -108,7 +108,7 @@ class BaseSpider(scrapy.Spider):
         success = False
 
         output_filename = f"{self.data_folder}/csv/{hsh}"
-        if save_csv and (".csv" not in output_filename):
+        if self.config["save_csv"] and ".csv" not in output_filename:
             output_filename += ".csv"
 
         if b'text/html' in response.headers['Content-type']:
@@ -117,7 +117,7 @@ class BaseSpider(scrapy.Spider):
                     f"{self.data_folder}/raw_pages/{hsh}.{file_format}",
                     is_string=False,
                     output_file=output_filename,
-                    to_csv=save_csv
+                    to_csv=self.config["save_csv"]
                 )
                 success = True
 
@@ -150,7 +150,7 @@ class BaseSpider(scrapy.Spider):
 
 
     def store_raw(
-            self, response, to_csv, file_format=None, binary=True, save_at="files"):
+            self, response, file_format=None, binary=True, save_at="files"):
         """Save response content."""
 
         if file_format is None:
@@ -195,12 +195,12 @@ class BaseSpider(scrapy.Spider):
         ) as f:
             f.write(body)
 
-        self.extract_and_store_csv(response, content, to_csv)
+        self.extract_and_store_csv(response, content)
 
-    def store_html(self, response, to_csv=False):
+    def store_html(self, response):
         """Stores html and adds its description to file_description file."""
         self.store_raw(
-            response, to_csv, file_format="html", binary=False, save_at="raw_pages")
+            response, file_format="html", binary=False, save_at="raw_pages")
         
 
     def errback_httpbin(self, failure):

--- a/crawlers/static_page.py
+++ b/crawlers/static_page.py
@@ -81,9 +81,9 @@ class StaticPageSpider(BaseSpider):
         if pattern != "":
             def allow(url):
                 if re.search(pattern, url) is not None:
-                    print(f"ADDING link {url}")
+                    print(f"ADDING link (passed regex filter) - {url}")
                     return True
-                print(f"IGNORING link {url}")
+                print(f"DISCARDING link (filtered by regex) - {url}")
                 return False
 
             urls_filtered = set(filter(allow, urls_found))

--- a/crawlers/static_page.py
+++ b/crawlers/static_page.py
@@ -80,7 +80,12 @@ class StaticPageSpider(BaseSpider):
         pattern = self.config["link_extractor_allow"]
         if pattern != "":
             def allow(url):
-                return re.search(pattern, url) is not None
+                if re.search(pattern, url) is not None:
+                    print(f"ADDING link {url}")
+                    return True
+                print(f"IGNORING link {url}")
+                return False
+
             urls_filtered = set(filter(allow, urls_found))
 
             for url in urls_found:
@@ -103,7 +108,7 @@ class StaticPageSpider(BaseSpider):
             return
 
         if b'text/html' in response_type:
-            self.store_html(response, self.config["save_csv"])
+            self.store_html(response)
             if "explore_links" in self.config and self.config["explore_links"]:
                 this_url = response.url
                 for url in self.extract_links(response):


### PR DESCRIPTION
O coletor estava quebrando pois em uma chamada do static_page existia uma chamada de uma função sem a passagem de um parametro obrigatorio. Acabei removendo o parametro totalmente já que é uma configuração acessível em todas as funções. Não faz sentido ficar carregando isso em parametros.

Adicionei uns prints na parte que filtra as ulrs descobertas pois eu estava adicionando essas linhas toda vez que fazia um coletor pra ajudar a debugar o filtro.

Close #230