### PR TITLE
Adiciona tela de downloads

### DIFF
--- a/crawlers/base_messenger.py
+++ b/crawlers/base_messenger.py
@@ -38,7 +38,7 @@ class BaseMessenger:
             f.write(json.dumps({"stop": True}))
 
     @staticmethod
-    def source(address, testing=False):
+    def source(address, testing=False, prepare_yield=lambda i: i):
         """
         Download source 'gambiarra'.
         Must be replaced by a kafka listener when integrations with Kafka and
@@ -48,6 +48,8 @@ class BaseMessenger:
         address -- str, address to folder that will contain new items
         testing -- do not use this argument. It is used to stop process if any
         error occurs during tests. (default False)
+        prepare_yield -- function that will be called with content being
+            yielded. Can make some preprossesing if necessary.
         """
         # Create essential files and folder
         try:
@@ -89,12 +91,12 @@ class BaseMessenger:
                 name = address + "/" + f
                 content = open(name, "r").read()
                 print("Yielding file", f, ", content:", content)
-                yield content
+                yield prepare_yield(content)
 
                 del file_check[f]
                 os.remove(name)
 
-            time.sleep(10)
+            time.sleep(5)
             with open(flag_file, "r") as f:
                 flags = json.loads(f.read())
                 print("flags:", flags)

--- a/main/apps.py
+++ b/main/apps.py
@@ -13,7 +13,8 @@ class MainConfig(AppConfig):
     server_running = False
 
     def runOnce(self):
-        steps_signature = parameter_extractor.get_module_functions_info(functions_file)
+        steps_signature = parameter_extractor.get_module_functions_info(
+            functions_file)
         with open('main/staticfiles/json/steps_signature.json', 'w+') as file:
             json.dump(steps_signature, file)
 
@@ -33,6 +34,10 @@ class MainConfig(AppConfig):
 
         # starts file descriptor and file downloader processes
         start_consumers_and_producers()
+
+        # cleaning download queue and current download
+        from .models import DownloadDetail
+        DownloadDetail.objects.all().delete()
 
     def ready(self):
         try:

--- a/main/models.py
+++ b/main/models.py
@@ -265,3 +265,18 @@ class CrawlerInstance(TimeStamped):
                                    related_name='instances')
     instance_id = models.BigIntegerField(primary_key=True)
     running = models.BooleanField()
+
+
+class DownloadDetail(TimeStamped):
+    """
+    Details about file downloads requested by crawlers.
+    """
+    STATUS = [
+        ('DOWNLOADING', 'DOWNLOADING'),
+        ('WAITING', 'WAITING'),
+        ('DONE', 'DONE'),
+    ]
+    status = models.CharField(max_length=20, choices=STATUS, default="WAITING") #, require=True)
+    description = models.CharField(max_length=1000, blank=True)
+    size = models.PositiveIntegerField(null=True, blank=True)
+    progress = models.PositiveIntegerField(null=True, blank=True)

--- a/main/serializers.py
+++ b/main/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .models import CrawlRequest, CrawlerInstance
+from .models import CrawlRequest, CrawlerInstance, DownloadDetail
 
 
 class CrawlerInstanceSerializer(serializers.ModelSerializer):
@@ -17,3 +17,13 @@ class CrawlRequestSerializer(serializers.ModelSerializer):
         model = CrawlRequest
         read_only_fields = ["id", "creation_date", "last_modified", "running"]
         fields = '__all__'
+
+class DownloadDetailSerializer(serializers.ModelSerializer):
+    def __init__(self, *args, **kwargs):
+        many = kwargs.pop('many', True)
+        super(DownloadDetailSerializer, self).__init__(many=many, *args, **kwargs)
+
+    class Meta:
+        model = DownloadDetail
+        read_only_fields = ["id", "creation_date", "last_modified"]
+        fields = "__all__"

--- a/main/staticfiles/css/downloads.css
+++ b/main/staticfiles/css/downloads.css
@@ -1,0 +1,40 @@
+h5 {
+    padding-top: 25px;
+}
+
+.download-item {
+    border: 1px solid #F5F1F0;
+    border-radius: 1px;
+    padding: 5px;
+}
+
+.download-item-ext {
+   margin: auto 0;
+   text-align: center; 
+}
+
+.download-item-links {
+    margin: auto 0;
+}
+
+.download-item-links p{
+    color: #1a73e8;
+    margin: 0;
+}
+
+.download-item-links a{
+    color: #5f6368;
+}
+
+.progress {
+    height: 15px;
+}
+
+.download-item-btns .col-2 {
+    padding-left: 0;
+}
+
+.download-item-info {
+    border: 1px solid  #F5F1F0;
+    border-top: 0px;
+}

--- a/main/staticfiles/js/downloads.js
+++ b/main/staticfiles/js/downloads.js
@@ -1,0 +1,124 @@
+
+var current_download = -1;
+
+$(document).ready(function () {
+    get_current_download();
+    get_download_list();
+    setInterval(
+        function () {
+            get_current_download();
+            get_download_list();
+        },
+        1000
+    );
+});
+
+function get_download_list(){
+    var xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = function () {
+        if (this.readyState == 4 && this.status == 200) {
+            var response = JSON.parse(this.responseText)["queue"];
+        
+            document.getElementById("file_queue").innerHTML = "";
+            for (var i = 0; i < response.length; i++) {
+                var curr = response[i];
+                console.log(JSON.parse(curr["description"]));
+                var url = JSON.parse(curr["description"])["url"];
+
+                var slices = url.split("/")
+                var file_name = slices[slices.length - 1];
+
+                slices = file_name.split(".")
+                var format = slices[slices.length - 1];
+
+                var html = `
+                    <div class="row download-item" id="file_${curr["id"]}_on_queue">
+                        <div class="col-1 download-item-ext">${format}</div>
+                        <div class="col download-item-links">
+                            <div class="row">
+                                <div class="col" style="padding: 10px 12px;">
+                                    <p>${file_name}</p>
+                                    <a href="${url}">${url}</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                `;
+                $('#file_queue').append(html);
+            }
+
+        }
+    };
+    xhr.open("GET", "/api/downloads/queue/", true);
+    xhr.send();
+}
+
+function get_current_download() {
+    var xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = function () {
+        if (this.readyState == 4 && this.status == 200) {
+            var response = JSON.parse(this.responseText);
+
+            if (!("progress" in response)){
+                return;
+            }
+
+            var download_progress = Math.round(100 * response["progress"] / response["size"]);
+            var desc = JSON.parse(response["description"]);
+
+            var url = desc["url"];
+            var slices = url.split("/");
+            var file_name = slices[slices.length - 1];
+
+            slices = file_name.split(".");
+            var format = slices[slices.length - 1];
+
+            if (response["id"] != current_download) {
+                response["id"] == current_download;
+
+                current_download = response["id"];
+                document.getElementById("file_downloading").innerHTML = "";
+                html = `
+                    <div class="row download-item" id="file_${response["id"]}">
+                        <div class="col-1 download-item-ext">${format}</div>
+                        <div class="col download-item-links">
+                            <div class="row">
+                                <div class="col" style="padding: 10px 12px;">
+                                    <p>${file_name}</p>
+                                    <a href="${url}">${url}</a>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col">
+                                    <div class="progress">
+                                        <div id="progress-bar" class="progress-bar bg-success" role="progressbar" style="width: ${download_progress}%;" 
+                                            aria-valuenow="${download_progress}" aria-valuemin="0" aria-valuemax="100">
+                                            ${download_progress}%
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row download-item-btns" display=None>
+                                <div class="col-2">
+                                    <button type="button" class="btn btn-link">Mostrar na pasta</button>
+                                </div>
+                                <div class="col"></div>
+                            </div>
+                        </div>
+                    </div>
+                `;
+
+                $("#file_downloading").append(html);
+            }
+            else {
+                var div = document.getElementById('file_downloading');
+                div = div.getElementsByClassName("progress-bar")[0];
+                div.setAttribute("aria-valuenow", download_progress);
+                div.style.width = `${download_progress}%`;
+                div.innerHTML = `${download_progress}%`;
+            }
+        }
+    };
+    xhr.open("GET", "/api/downloads/progress/", true);
+    xhr.send();
+}

--- a/main/templates/main/base.html
+++ b/main/templates/main/base.html
@@ -8,6 +8,7 @@
     {% load static %}
     <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}" />
     <title>{% block title %}{% endblock%}</title>
+    {% block style %}{% endblock%}
 </head>
 <body>
     <!-- Bootstrap NavBar -->
@@ -21,6 +22,7 @@
                 <!-- <li class="nav-item"><a class="nav-link" href="#">Monitor <span class="sr-only">(current)</span></a></li> -->
                 <li class="nav-item"><a class="nav-link" href="/crawlers">Coletores</a></li>
                 <li class="nav-item"><a class="nav-link" href="/new">Criar coletor</a></li>
+                <li class="nav-item"><a class="nav-link" href="/downloads">Downloads</a></li>
             </ul>
         </div>
     </nav>

--- a/main/templates/main/downloads.html
+++ b/main/templates/main/downloads.html
@@ -1,0 +1,37 @@
+{% extends 'main/base.html' %}
+
+{% block title %}
+Downloads
+{% endblock %}
+
+{% block style %}
+{% load static %}
+<link rel="stylesheet" type="text/css" href="{% static 'css/downloads.css' %}" />
+{% endblock%}
+
+{% block content %}
+<div class="row">
+    <div class="col-2"></div>
+    <div class="col">
+        <div class="row"><div class="col"><h5>Baixando: </h5></div></div>
+        <div class="row"><div id="file_downloading" class="col"></div></div>
+    </div>
+    <div class="col-2"></div>
+</div>
+
+<div class="row">
+    <div class="col-2"></div>
+    <div class="col">
+        <div class="row"><div class="col"><h5>Na fila: </h5></div></div>
+        <div class="row"><div id="file_queue" class="col"></div></div>
+        <div id="file_queue"></div>
+    </div>
+    <div class="col-2"></div>
+</div>
+
+{% endblock %}
+
+{% block js %}
+{% load static %}
+<script src="{% static 'js/downloads.js' %}"></script>
+{% endblock %}

--- a/main/urls.py
+++ b/main/urls.py
@@ -8,6 +8,7 @@ from . import views
 api_router = routers.DefaultRouter()
 api_router.register(r'crawlers', views.CrawlerViewSet)
 api_router.register(r'instances', views.CrawlerInstanceViewSet)
+api_router.register(r'downloads', views.DownloadDetailsViewSet)
 
 urlpatterns = [
     path("", views.list_crawlers, name="list_crawlers"),
@@ -21,6 +22,7 @@ urlpatterns = [
     path("detail/run_crawl/<int:crawler_id>", views.run_crawl, name="run_crawl"),
     path("detail/stop_crawl/<int:crawler_id>", views.stop_crawl, name="stop_crawl"),
     path("tail_log_file/<str:instance_id>", views.tail_log_file, name="tail_log_file"),
+    path("downloads/", views.downloads, name="downloads"),
 
     # Includes the API endpoints in the URLs
     url(r'^api/', include(api_router.urls)),

--- a/main/views.py
+++ b/main/views.py
@@ -9,8 +9,9 @@ from rest_framework.decorators import action
 
 from .forms import CrawlRequestForm, RawCrawlRequestForm,\
                    ResponseHandlerFormSet, ParameterHandlerFormSet
-from .models import CrawlRequest, CrawlerInstance
-from .serializers import CrawlRequestSerializer, CrawlerInstanceSerializer
+from .models import CrawlRequest, CrawlerInstance, DownloadDetail
+from .serializers import CrawlRequestSerializer, CrawlerInstanceSerializer, \
+                        DownloadDetailSerializer
 
 from crawlers.constants import *
 
@@ -19,6 +20,9 @@ from datetime import datetime
 import time
 
 import crawlers.crawler_manager as crawler_manager
+
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework.parsers import JSONParser
 
 # Helper methods
 
@@ -214,6 +218,10 @@ def tail_log_file(request, instance_id):
         "time": str(datetime.fromtimestamp(time.time())),
     })
 
+
+def downloads(request):
+    return render(request, "main/downloads.html")
+
 # API
 ########
 
@@ -232,6 +240,12 @@ GET       /api/crawlers/<id>/run    run crawler instance
 GET       /api/crawlers/<id>/stop   stop crawler instance
 GET       /api/instances/           list crawler instances
 GET       /api/instances/<id>       crawler instance detail
+GET       /api/downloads/<id>       return details about download itens
+GET       /api/downloads/           return list of download itens
+POST      /api/downloads/           create a download item
+PUT       /api/downloads/<id>       update download item
+GET       /api/downloads/queue      return list of items in download queue
+GET       /api/downloads/progress   return info about current download
 """
 
 
@@ -285,3 +299,37 @@ class CrawlerInstanceViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = CrawlerInstance.objects.all()
     serializer_class = CrawlerInstanceSerializer
+
+
+class DownloadDetailsViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows users to be viewed or edited.
+    """
+    queryset = DownloadDetail.objects.all().order_by('-last_modified')
+    serializer_class = DownloadDetailSerializer
+
+    @action(detail=False)
+    def queue(self, request):
+        instances =  DownloadDetail.objects.filter(
+            status="WAITING").order_by('creation_date')
+
+        response = {"queue": [DownloadDetailSerializer(i).data for i in instances]}
+
+        return JsonResponse(response)
+
+    @action(detail=False)
+    def progress(self, request):
+        instances =  DownloadDetail.objects.filter(
+            status="DOWNLOADING").order_by('-last_modified')
+        
+        if len(instances):
+            return JsonResponse(DownloadDetailSerializer(instances[0]).data)
+
+        return JsonResponse({})
+
+
+"""
+TODO
+add api to downloader
+finish screen
+"""


### PR DESCRIPTION
Criei uma API para receber o progresso do downloads de arquivos, e uma nova tela à interface que mostra essas informações.

Essa abordagem ainda tem alguns problemas, mas o PR já estava muito grande então vou arrumar depois que essas alterações forem revisadas.  Quando forem testar vão perceber que o download de um mesmo arquivo é feito diversas vezes. Se você abrir o log do file_downloader vai ver que ele recebe um keyboard interrupt diversas vezes, o que interrompe os downloads. Quem manda essa mensagem é o django, que por algum motivo reinicia diversas vezes durante a execução. O processo do file_downloader e do file_descriptor vão ter que ser independente do django, mas não sei ainda como vou amarrar a execução dos três (iniciar os processos quando o django iniciar e só finalizar quando o django for encerrado de fato).