### PR TITLE
Issue #218 - Adiciona script de inicialização de processos

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ pip install .
 
 Para execução da interface basta executar o seguinte comando:
 ```
-python manage.py runserver
+python run.py
 ```
 
 E então basta acessar _http://localhost:8000/_
 
 Se quiser acessar o programa através da rede, execute:
 ```
-python manage.py runserver 0.0.0.0:8000
+python run.py 0.0.0.0:8000
 ```
 E então use o IP da máquina onde a interface está sendo executada para acessá-la. Por exemplo, se a máquina onde você rodou o comando acima tem endereço de IP _1.2.3.4_, e esse endereço é visível para sua máquina através da rede, você pode acessar _http://1.2.3.4:8000/_.
 

--- a/crawlers/crawler_manager.py
+++ b/crawlers/crawler_manager.py
@@ -46,15 +46,6 @@ def file_descriptor_process():
     FileDescriptor.description_consumer()
 
 
-def start_consumers_and_producers():
-    """Starts file_description and file_downlaoder processes."""
-    downloader = Process(target=file_downloader_process)
-    downloader.start()
-
-    descriptor = Process(target=file_descriptor_process)
-    descriptor.start()
-
-
 def create_folders(data_path):
     """Create essential folders for crawlers if they do not exists"""
     files = [

--- a/crawlers/file_downloader.py
+++ b/crawlers/file_downloader.py
@@ -68,11 +68,11 @@ class FileDownloader(BaseMessenger):
         - description: dict, dictionary of item descriptions
         """
 
-        url_hash = crawling_utils.hash(item["url"])
+        url_hash = crawling_utils.hash(item["url"].encode())
         old_file_name = item["description"]["file_name"]
         item["description"]["file_name"] = f"{url_hash}.csv"
         item["description"]["type"] = "csv"
-        url_hash = crawling_utils.hash(item["url"])
+        url_hash = crawling_utils.hash(item["url"].encode())
 
         success = False
 

--- a/main/apps.py
+++ b/main/apps.py
@@ -5,9 +5,6 @@ from step_crawler import functions_file
 import json
 
 
-from crawlers.crawler_manager import start_consumers_and_producers
-
-
 class MainConfig(AppConfig):
     name = 'main'
     server_running = False
@@ -31,9 +28,6 @@ class MainConfig(AppConfig):
         for instance in instances:
             instance.running = False
             instance.save()
-
-        # starts file descriptor and file downloader processes
-        start_consumers_and_producers()
 
         # cleaning download queue and current download
         from .models import DownloadDetail

--- a/run.py
+++ b/run.py
@@ -1,0 +1,120 @@
+import multiprocessing
+import signal
+import time
+import sys
+import subprocess
+
+from crawlers.crawler_manager import file_downloader_process, \
+    file_descriptor_process
+
+# GLOBAL VARIABLES
+
+stop_processes = False
+process_exception = None
+n_processes_running = 0
+global_lock = multiprocessing.Lock()
+
+# END GLOBAL VARIABLES
+
+# FUNCTIONS THAT SHOULD BE EXECUTED BY PROCESSES
+
+N_FUNCTIONS = 3
+
+def run_django():
+    # Runs django repassing cli parameters
+    subprocess.run(["python", "manage.py", "runserver"] + sys.argv[1:])
+    time.sleep(10)
+
+def run_file_downloader():
+    file_downloader_process()
+
+def runn_file_descriptor():
+    file_descriptor_process()
+
+# END FUNCTIONS THAT SHOULD BE EXECUTED BY PROCESSES
+
+def init_process():
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+
+def run_process(i, error_on):
+    time.sleep(i)
+    if i == error_on:
+        raise FileNotFoundError
+    print(i, "seconds - done")
+
+
+def signal_done(r):
+    global global_logk, n_processes_running
+    with global_lock:
+        n_processes_running -= 1
+
+
+def signal_stop(e):
+    global stop_processes, process_exception
+    stop_processes = True
+    process_exception = e
+
+
+def run():
+    global stop_processes, process_exception, n_processes_running, global_lock
+
+    print("Initializing processes")
+    pool = multiprocessing.Pool(
+        processes=N_FUNCTIONS,
+        initializer=init_process,
+    )
+
+    # List functions that will be executed by processes
+    with global_lock:
+        n_processes_running = N_FUNCTIONS
+
+    # N_FUNCTIONS must be equal to len(functions)
+    functions = [
+        [run_django, []],
+        [run_file_downloader, []],
+        [runn_file_descriptor, []],
+    ]
+    for (f, args) in functions:
+        pool.apply_async(
+            func=f,
+            args=args,
+            callback=signal_done,
+            error_callback=signal_stop,
+        )
+    # end list function
+
+    try:
+        while True:
+            with global_lock:
+                # stop processes if any of them stopped running
+                if n_processes_running != N_FUNCTIONS:
+                    print("A process ended, terminating processes...")
+                    break
+
+            time.sleep(5)
+            if stop_processes:
+                # re-raise an excetion raised by one of the processes
+                raise process_exception
+
+    except KeyboardInterrupt:
+        # stop process on KeyboardInterrupt
+        print("KeyboardInterrupt, terminating processes...")
+        pool.terminate()
+        pool.join()
+
+    except Exception as e:
+        # re-raises process exception and stop processes, printing traceback
+        print("A process failed, terminating processes...")
+        pool.terminate()
+        pool.join()
+        raise e   
+
+    else:
+        # stop processes
+        pool.terminate()
+        pool.join()
+
+
+if __name__ == "__main__":
+    run()

--- a/run.py
+++ b/run.py
@@ -20,18 +20,22 @@ global_lock = multiprocessing.Lock()
 
 N_FUNCTIONS = 3
 
+
 def run_django():
     # Runs django repassing cli parameters
     subprocess.run(["python", "manage.py", "runserver"] + sys.argv[1:])
     time.sleep(10)
 
+
 def run_file_downloader():
     file_downloader_process()
+
 
 def runn_file_descriptor():
     file_descriptor_process()
 
 # END FUNCTIONS THAT SHOULD BE EXECUTED BY PROCESSES
+
 
 def init_process():
     signal.signal(signal.SIGINT, signal.SIG_IGN)
@@ -108,7 +112,7 @@ def run():
         print("A process failed, terminating processes...")
         pool.terminate()
         pool.join()
-        raise e   
+        raise e
 
     else:
         # stop processes


### PR DESCRIPTION
O django reinicia por conta própria diversas vezes durante a execução e isso interrompia e recomeçava os downloads de arquivos. É necessário então separar o módulo de download de arquivos da thread principal, mas de maneira que caso o django seja encerrado, o módulo de download também seja. 

Criei um script de inicialização chamado ``run.py`` que amarra a execução dos processos criados. A interface agora deve ser executada usando este script (``python run.py``). Ele funciona da seguinte maneira:
- parametros passados para o script serão repassados para o comando ``python manage.py runserver``. Se você quiser por exemplo mudar a porta do django, basta rodar ``python run.py 8001``, que terá o mesmo efeito que rodar ``python manage.py runserver 8001`` teria;
- se um processo terminar, os outros serão encerrados;
- se um processo disparar uma exceção, os outros serão encerrados e a exceção será impressa na tela;
- se você enviar um sinal de KeyboardInterrupt (``ctrl + c``), todos os processos serão encerrados;

Tentei deixar de uma maneira que é fácil adicionar novos módulos a serem executados, como parece que vai ser necessário futuramente.