### PR TITLE
Issue 218 - Adiciona opção para permitir download de imagens

### DIFF
--- a/crawlers/static_page.py
+++ b/crawlers/static_page.py
@@ -10,6 +10,7 @@ import requests
 
 # Project libs
 from crawlers.base_spider import BaseSpider
+import crawling_utils
 
 
 class StaticPageSpider(BaseSpider):
@@ -99,6 +100,19 @@ class StaticPageSpider(BaseSpider):
 
         return urls_found
 
+    def extract_imgs(self, response):
+        url_domain = crawling_utils.get_url_domain(response.url)
+
+        src = []
+        for img in response.xpath("//img"):
+            img_src = img.xpath('@src').extract_first()
+            if img_src[0] == '/':
+                img_src = url_domain + img_src[1:]
+            src.append(img_src)
+        
+        print(f"imgs found at page {response.url}", src)
+        return set(src)
+
     def parse(self, response):
         """
         Parse responses of static pages.
@@ -112,20 +126,28 @@ class StaticPageSpider(BaseSpider):
         if self.stop():
             return
 
-        if b'text/html' in response_type:
-            self.store_html(response)
-            if "explore_links" in config and config["explore_links"]:
-                this_url = response.url
-                for url in self.extract_links(response):
-                    yield scrapy.Request(
-                        url=url, callback=self.parse,
-                        meta={"referer": response.url,
-                              "config": config},
-                        errback=self.errback_httpbin
-                    )
-
-            if self.config["download_files"]:
-                for file in self.extract_files(response):
-                    self.feed_file_downloader(file, response)
-        else:
+        if b'text/html' not in response_type:
             self.store_raw(response)
+            return
+
+        self.store_html(response)
+        if "explore_links" in config and config["explore_links"]:
+            this_url = response.url
+            for url in self.extract_links(response):
+                yield scrapy.Request(
+                    url=url, callback=self.parse,
+                    meta={"referer": response.url,
+                            "config": config},
+                    errback=self.errback_httpbin
+                )
+
+        if "download_files" in self.config and self.config["download_files"]:
+            for file in self.extract_files(response):
+                self.feed_file_downloader(file, response)
+        
+        print("download_imgs", self.config["download_imgs"])
+        if "download_imgs" in self.config and self.config["download_imgs"]:
+            for img_url in self.extract_imgs(response):
+                print("feeding", img_url)
+                self.feed_file_downloader(img_url, response)
+

--- a/crawlers/static_page.py
+++ b/crawlers/static_page.py
@@ -109,7 +109,7 @@ class StaticPageSpider(BaseSpider):
             if img_src[0] == '/':
                 img_src = url_domain + img_src[1:]
             src.append(img_src)
-        
+
         print(f"imgs found at page {response.url}", src)
         return set(src)
 
@@ -136,18 +136,16 @@ class StaticPageSpider(BaseSpider):
             for url in self.extract_links(response):
                 yield scrapy.Request(
                     url=url, callback=self.parse,
-                    meta={"referer": response.url,
-                            "config": config},
+                    meta={"referer": response.url, "config": config},
                     errback=self.errback_httpbin
                 )
 
         if "download_files" in self.config and self.config["download_files"]:
             for file in self.extract_files(response):
                 self.feed_file_downloader(file, response)
-        
+
         print("download_imgs", self.config["download_imgs"])
         if "download_imgs" in self.config and self.config["download_imgs"]:
             for img_url in self.extract_imgs(response):
                 print("feeding", img_url)
                 self.feed_file_downloader(img_url, response)
-

--- a/main/forms.py
+++ b/main/forms.py
@@ -49,6 +49,7 @@ class CrawlRequestForm(forms.ModelForm):
             'download_files',
             'download_files_allow_url',
             'download_files_allow_extensions',
+            'download_imgs',
             'steps',
             'save_csv',
             'data_path',
@@ -243,6 +244,7 @@ class RawCrawlRequestForm(CrawlRequestForm):
 
     download_files = forms.BooleanField(
         required=False, label="Baixar arquivos")
+
     download_files_allow_url = forms.CharField(
         required=False, max_length=2000,
         label=(
@@ -252,11 +254,16 @@ class RawCrawlRequestForm(CrawlRequestForm):
         widget=forms.TextInput(
             attrs={'placeholder': 'Regex para permitir urls'})
     )
+
     download_files_allow_extensions = forms.CharField(
         required=False, max_length=2000,
         label="Extensões de arquivo permitidas (separado por vírgula):",
         widget=forms.TextInput(attrs={'placeholder': 'pdf,xml'})
     )
+
+    download_imgs = forms.BooleanField(
+        required=False, label="Baixar imagens")
+
     # Crawler Type - Page with form
     steps = forms.CharField(required=False, label="Steps JSON", max_length=9999999,
                             widget=forms.TextInput(

--- a/main/models.py
+++ b/main/models.py
@@ -112,7 +112,8 @@ class CrawlRequest(TimeStamped):
         max_length=15, choices=CRAWLER_TYPE, default='static_page')
     explore_links = models.BooleanField(blank=True, null=True)
     link_extractor_max_depth = models.IntegerField(blank=True, null=True)
-    link_extractor_allow_url = models.CharField(max_length=1000, blank=True, null=True)
+    link_extractor_allow_url = models.CharField(
+        max_length=1000, blank=True, null=True)
 
     download_files = models.BooleanField(blank=True, null=True)
     download_files_allow_url = models.CharField(
@@ -120,7 +121,10 @@ class CrawlRequest(TimeStamped):
     download_files_allow_extensions = models.CharField(
         blank=True, null=True, max_length=2000)
 
-    steps = models.CharField(blank=True, null=True, max_length=9999999, default='{}')
+    download_imgs = models.BooleanField(default=False)
+
+    steps = models.CharField(
+        blank=True, null=True, max_length=9999999, default='{}')
 
     @staticmethod
     def process_config_data(crawler, config):
@@ -275,9 +279,11 @@ class DownloadDetail(TimeStamped):
         ('DOWNLOADING', 'DOWNLOADING'),
         ('WAITING', 'WAITING'),
         ('DONE', 'DONE'),
+        ('ERROR', 'ERROR')
     ]
     status = models.CharField(
         max_length=20, choices=STATUS, default="WAITING")
     description = models.CharField(max_length=1000, blank=True)
     size = models.PositiveIntegerField(null=True, blank=True)
     progress = models.PositiveIntegerField(null=True, blank=True)
+    error_message = models.CharField(max_length=1000, null=True, blank=True)

--- a/main/staticfiles/js/downloads.js
+++ b/main/staticfiles/js/downloads.js
@@ -8,10 +8,57 @@ $(document).ready(function () {
         function () {
             get_current_download();
             get_download_list();
+            get_error_list();
         },
         1000
     );
 });
+
+function get_error_list(){
+    var xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = function () {
+        if (this.readyState == 4 && this.status == 200) {
+            var response = JSON.parse(this.responseText)["error"];
+
+            document.getElementById("file_error").innerHTML = "";
+            for (var i = 0; i < response.length; i++) {
+                var curr = response[i];
+                console.log(JSON.parse(curr["description"]));
+                var url = JSON.parse(curr["description"])["url"];
+
+                var slices = url.split("/")
+                var file_name = slices[slices.length - 1];
+
+                slices = file_name.split(".")
+                var format = slices[slices.length - 1];
+                if (format.length > 4) format = "???";
+
+                var html = `
+                    <div class="row download-item" id="file_${curr["id"]}_on_queue">
+                        <div class="col-1 download-item-ext">${format}</div>
+                        <div class="col download-item-links">
+                            <div class="row">
+                                <div class="col" style="padding: 10px 12px;">
+                                    <p>${file_name}</p>
+                                    <a href="${url}">${url}</a>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col" style="padding: 10px 12px;">
+                                    <p>${curr["error_message"]}</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                `;
+                $('#file_error').append(html);
+            }
+
+        }
+    };
+    xhr.open("GET", "/api/downloads/error/", true);
+    xhr.send();
+}
 
 function get_download_list(){
     var xhr = new XMLHttpRequest();
@@ -30,6 +77,7 @@ function get_download_list(){
 
                 slices = file_name.split(".")
                 var format = slices[slices.length - 1];
+                if (format.length > 4) format = "???";
 
                 var html = `
                     <div class="row download-item" id="file_${curr["id"]}_on_queue">
@@ -72,6 +120,7 @@ function get_current_download() {
 
             slices = file_name.split(".");
             var format = slices[slices.length - 1];
+            if (format.length > 4) format = "???";
 
             if (response["id"] != current_download) {
                 response["id"] == current_download;

--- a/main/templates/main/create_crawler.html
+++ b/main/templates/main/create_crawler.html
@@ -261,6 +261,9 @@ New Crawler
                                         {{ form.download_files_allow_url | as_crispy_field}}
                                         {{ form.download_files_allow_extensions | as_crispy_field}}
                                     </div>
+                                    <div id="download_files" style="padding:20px; border-top: 1px solid #DCDCDC;">
+                                        {{ form.download_imgs | as_crispy_field}}
+                                    </div>
                                 </div>
                                 <div class="crawler-type-content-div" id="form_page" hidden>
                                     {{ form.steps |  as_crispy_field }}

--- a/main/templates/main/downloads.html
+++ b/main/templates/main/downloads.html
@@ -24,7 +24,15 @@ Downloads
     <div class="col">
         <div class="row"><div class="col"><h5>Na fila: </h5></div></div>
         <div class="row"><div id="file_queue" class="col"></div></div>
-        <div id="file_queue"></div>
+    </div>
+    <div class="col-2"></div>
+</div>
+
+<div class="row">
+    <div class="col-2"></div>
+    <div class="col">
+        <div class="row"><div class="col"><h5>Downloads com erro: </h5></div></div>
+        <div class="row"><div id="file_error" class="col"></div></div>
     </div>
     <div class="col-2"></div>
 </div>

--- a/main/views.py
+++ b/main/views.py
@@ -246,6 +246,7 @@ POST      /api/downloads/           create a download item
 PUT       /api/downloads/<id>       update download item
 GET       /api/downloads/queue      return list of items in download queue
 GET       /api/downloads/progress   return info about current download
+GET       /api/downloads/error      return info about download errors
 """
 
 
@@ -328,3 +329,14 @@ class DownloadDetailsViewSet(viewsets.ModelViewSet):
             return JsonResponse(DownloadDetailSerializer(instances[0]).data)
 
         return JsonResponse({})
+
+    @action(detail=False)
+    def error(self, request):
+        instances = DownloadDetail.objects.filter(
+            status="ERROR").order_by('-last_modified')
+
+        response = {
+            "error": [DownloadDetailSerializer(i).data for i in instances]
+        }
+
+        return JsonResponse(response)

--- a/run.py
+++ b/run.py
@@ -24,7 +24,6 @@ N_FUNCTIONS = 3
 def run_django():
     # Runs django repassing cli parameters
     subprocess.run(["python", "manage.py", "runserver"] + sys.argv[1:])
-    time.sleep(10)
 
 
 def run_file_downloader():
@@ -39,13 +38,6 @@ def runn_file_descriptor():
 
 def init_process():
     signal.signal(signal.SIGINT, signal.SIG_IGN)
-
-
-def run_process(i, error_on):
-    time.sleep(i)
-    if i == error_on:
-        raise FileNotFoundError
-    print(i, "seconds - done")
 
 
 def signal_done(r):
@@ -69,16 +61,18 @@ def run():
         initializer=init_process,
     )
 
-    # List functions that will be executed by processes
-    with global_lock:
-        n_processes_running = N_FUNCTIONS
 
-    # N_FUNCTIONS must be equal to len(functions)
+    # List functions that will be executed by processes
     functions = [
         [run_django, []],
         [run_file_downloader, []],
         [runn_file_descriptor, []],
     ]
+
+    # N_FUNCTIONS must be equal to len(functions)
+    with global_lock:
+        n_processes_running = N_FUNCTIONS
+
     for (f, args) in functions:
         pool.apply_async(
             func=f,

--- a/run.py
+++ b/run.py
@@ -61,7 +61,6 @@ def run():
         initializer=init_process,
     )
 
-
     # List functions that will be executed by processes
     functions = [
         [run_django, []],

--- a/src/crawling_utils/crawling_utils/crawling_utils.py
+++ b/src/crawling_utils/crawling_utils/crawling_utils.py
@@ -3,6 +3,14 @@ from selenium.webdriver.common.keys import Keys
 import time
 import hashlib
 import os
+from urllib.parse import urlparse
+
+
+def get_url_domain(url):
+    parsed_uri = urlparse(url)
+    result = '{uri.scheme}://{uri.netloc}/'.format(uri=parsed_uri)
+    return result
+
 
 def hash(byte_content):
     """Returns the md5 hash of a bytestring."""


### PR DESCRIPTION
Esse PR toca vários arquivos mas as alterações são pequenas. Adicionei algumas features ao projeto:

- Agora é possível configurar download de imagens na tela de configurações de coletores para páginas estáticas
  - Quando não é possível identificar a extensão da imagem facilmente, a imagem será baixada sem extensão. Por ex.: a url [https://static.wikia.nocookie.net/minecraft_gamepedia/images/4/48/Netherite_Sword_JE2.png/revision/latest/scale-to-width-down/160?cb=20200304213920](https://static.wikia.nocookie.net/minecraft_gamepedia/images/4/48/Netherite_Sword_JE2.png/revision/latest/scale-to-width-down/160?cb=20200304213920)
- Criei uma nova endpoint com informações sobre downloads que falharam
- A tela de downloads agora lista os downloads que falharam junto com suas mensagens de erro
- Adicionei uma função para extrair o domínio de uma url ao crawler_utils.

Sobre Testes. Pode testar com as páginas que achar melhor, mas sugiro duas:
1. Esse site de mangas online [mangahub](https://mangahub.io/manga/solo-leveling_105) não permite a coleta de imagens, então todos os downloads vão dar erro. Coloque apenas o endereço, a pasta onde quer salvar e ligue apenas a opção de baixar imagens. Não é necessário explorar links ou outros arquivos.
2. Esse site ["minecraft wiki - sword"](https://minecraft.gamepedia.com/Sword) tem dezenas de imagens pequenas para baixar. Algumas delas não tem extensão no fim da extensão em src, e o arquivo será criado sem extensão, sendo listado na aba de downloads como '???'. Mesma configuração: apenas url, pasta e permitir a coleta de imagens. 

close #218 

Edit: Tentei recuperar as imagens usando o LinkExtractor com configurações {tag = ('img', ), attr = ('src', )} mas não consegui fazer funcionar por algum motivo.