### PR TITLE
Issue 295 - Adiciona funcionalidades ao file_downloader

### DIFF
--- a/crawlers/base_messenger.py
+++ b/crawlers/base_messenger.py
@@ -38,7 +38,7 @@ class BaseMessenger:
             f.write(json.dumps({"stop": True}))
 
     @staticmethod
-    def source(address, testing=False, prepare_yield=lambda i: i):
+    def source(address, testing=False):
         """
         Download source 'gambiarra'.
         Must be replaced by a kafka listener when integrations with Kafka and
@@ -48,8 +48,6 @@ class BaseMessenger:
         address -- str, address to folder that will contain new items
         testing -- do not use this argument. It is used to stop process if any
         error occurs during tests. (default False)
-        prepare_yield -- function that will be called with content being
-            yielded. Can make some preprossesing if necessary.
         """
         # Create essential files and folder
         try:
@@ -80,7 +78,7 @@ class BaseMessenger:
                 if f == "flags.json":
                     continue
 
-                print(f"Found file {f}")
+                # print(f"Found file {f}")
 
                 if f not in file_check:
                     file_check[f] = 0
@@ -91,7 +89,7 @@ class BaseMessenger:
                 name = address + "/" + f
                 content = open(name, "r").read()
                 print("Yielding file", f, ", content:", content)
-                yield prepare_yield(content)
+                yield content
 
                 del file_check[f]
                 os.remove(name)
@@ -99,7 +97,8 @@ class BaseMessenger:
             time.sleep(5)
             with open(flag_file, "r") as f:
                 flags = json.loads(f.read())
-                print("flags:", flags)
                 stop = flags["stop"]
+                if stop:
+                    print("Sinalized to stop.")
 
         shutil.rmtree(address)

--- a/crawlers/base_spider.py
+++ b/crawlers/base_spider.py
@@ -323,12 +323,15 @@ class BaseSpider(scrapy.Spider):
             self.logger.error('TimeoutError on %s', request.url)
 
     def feed_file_downloader(self, url, response_origin):
+        wait_end = self.config["wait_crawler_finish_to_download"]
         description = {
             "url": url,
             "crawler_id": self.config["crawler_id"],
             "instance_id": self.config["instance_id"],
             "crawled_at_date": str(datetime.datetime.today()),
-            "referer": response_origin.url
+            "referer": response_origin.url,
+            "wait_crawler_finish_to_download": wait_end,
+            "time_between_downloads": self.config["time_between_downloads"],
         }
         FileDownloader.feed_downloader(url, self.data_folder, description)
 

--- a/crawlers/file_downloader.py
+++ b/crawlers/file_downloader.py
@@ -181,7 +181,12 @@ class FileDownloader(BaseMessenger):
 
             FileDownloader.process_item(item)
 
-            next_download = int(time.time()) + item["time_between_downloads"]
+            if item["time_between_downloads"] is None:
+                add = 60
+            else:
+                add = item["time_between_downloads"]
+            next_download = int(time.time()) + add
+
             with lock:
                 if wait_line[item_key].qsize() > 0:
                     heapq.heappush(heap, (next_download, item_key))

--- a/crawlers/file_downloader.py
+++ b/crawlers/file_downloader.py
@@ -181,11 +181,7 @@ class FileDownloader(BaseMessenger):
 
             FileDownloader.process_item(item)
 
-            if item["time_between_downloads"] is None:
-                add = 60
-            else:
-                add = item["time_between_downloads"]
-            next_download = int(time.time()) + add
+            next_download = int(time.time()) + item["time_between_downloads"]
             with lock:
                 if wait_line[item_key].qsize() > 0:
                     heapq.heappush(heap, (next_download, item_key))

--- a/crawlers/file_downloader.py
+++ b/crawlers/file_downloader.py
@@ -181,7 +181,11 @@ class FileDownloader(BaseMessenger):
 
             FileDownloader.process_item(item)
 
-            next_download = int(time.time()) + item["time_between_downloads"]
+            if item["time_between_downloads"] is None:
+                add = 60
+            else:
+                add = item["time_between_downloads"]
+            next_download = int(time.time()) + add
             with lock:
                 if wait_line[item_key].qsize() > 0:
                     heapq.heappush(heap, (next_download, item_key))

--- a/crawlers/file_downloader.py
+++ b/crawlers/file_downloader.py
@@ -3,6 +3,10 @@ import datetime
 import json
 import wget
 import requests
+import heapq
+import queue
+import threading
+import time
 
 # Project libs
 import binary
@@ -13,6 +17,7 @@ from crawlers.base_messenger import BaseMessenger
 
 class FileDownloader(BaseMessenger):
     TEMP_FILES_FOLDER = "temp_files_to_download" 
+    TIME_BETWEEN_SAME_DOMAIN_REQUEST = 60 # SECONDS
 
     @staticmethod
     def feed_downloader(url, destination, description):
@@ -26,12 +31,18 @@ class FileDownloader(BaseMessenger):
         destination -- str, address of the folder that will containt the file
         description -- dict, dictionary of item descriptions
         """
+        cid = description["crawler_id"]
+        wait = description["wait_crawler_finish_to_download"]
+        time_between = description["time_between_downloads"]
         BaseMessenger.feed(
             FileDownloader.TEMP_FILES_FOLDER,
             {
                 "url": url,
                 "destination": destination,
-                "description": description
+                "description": description,
+                "crawler_id": cid,
+                "wait_crawler_finish_to_download": wait,
+                "time_between_downloads": time_between,
             }
         )
 
@@ -54,8 +65,7 @@ class FileDownloader(BaseMessenger):
         error occurs during tests. (default False)
         """
         source = BaseMessenger.source(
-            FileDownloader.TEMP_FILES_FOLDER,
-            testing, FileDownloader.log_item)
+            FileDownloader.TEMP_FILES_FOLDER, testing)
         for item in source:
             yield item
         
@@ -93,7 +103,215 @@ class FileDownloader(BaseMessenger):
                 item['destination'] + "csv/", item['description'])
 
     @staticmethod
-    def download_consumer(max_attempts=3, testing=False):
+    def process_item(item):
+        max_attempts = 3
+        success = False
+        error_message = ""
+        for attempt in range(1, max_attempts + 1):
+            print(
+                "Trying to download file "
+                f"(attempt {attempt}/{max_attempts}): ",
+                item["url"]
+            )
+            try:
+                FileDownloader.download_file(item)
+                print("Downloaded", item["url"], "successfully.")
+                success = True
+
+                FileDownloader.convert_binary(item)
+                break
+            except Exception as e:
+                print(
+                    f"{attempt}-th attempt to download \"{item['url']}\" "
+                    f"failed. Error message: {str(type(e))}-{e}"
+                )
+                print("Will sleep for 10 seconds before trying again.")
+                time.sleep(10 * attempt)
+                error_message = str(e)
+
+        if not success:
+            print("All attempts to download", item["url"], "failed.")
+            response = requests.put(
+                f'http://localhost:8000/api/downloads/{item["id"]}/',
+                data={
+                    "status": "ERROR",
+                    "error_message": error_message
+                }
+            )
+
+    @staticmethod
+    def internal_consumer(
+        wait_line, heap, stop, in_heap, 
+        downloads_waiting, lock
+    ):
+        print("Starting internal_consumer")
+        """
+        Get items from domain downloaded as early as posisble, and check for
+        politiness.
+        - wait_line - list of itens to download by domain
+        - heap - min heap of (last access, domain)
+        - stop - says if threads were told to stop by file flag
+        - in_heap - marks if domain is in the heap
+        - downloads_waiting - marks downloads waiting craler to finish
+        - lock - lock to access variables above
+        """
+        local_stop = False
+
+        need_to_sleep = False
+
+        while not local_stop:
+            if need_to_sleep:
+                time.sleep(5)
+                need_to_sleep = False
+
+            item_key = None
+            item = None
+            
+            with lock:
+                print("First on heap:", heap[:1])
+                if len(heap) == 0 or time.time() < heap[0][0]:
+                    local_stop = stop # update local stop
+                    need_to_sleep = True
+                    print("Too soon to download. Sleeping...")
+                    continue
+
+                (_, item_key) = heapq.heappop(heap)
+                item = wait_line[item_key].get()
+            
+            print(f"internal_consumer - Starting key: {item_key}, {item['url']},")
+            
+            FileDownloader.process_item(item)
+
+            next_download = int(time.time()) + item["time_between_downloads"]
+            with lock:
+                if wait_line[item_key].qsize() > 0:
+                    heapq.heappush(heap, (next_download, item_key))
+                else:
+                    in_heap[item_key] = False
+                print(f"re-building heap: {heap}")
+                local_stop = stop
+
+    def internal_producer(
+        wait_line, heap, stop, in_heap, 
+        downloads_waiting, lock,
+        testing=False
+    ):
+        print("Starting internal_producer")
+        """
+        Get items from FileDownloader.download_source and put on wait heap,
+        so we can change between domains.
+        - wait_line - list of itens to download by domain
+        - heap - min heap of (last access, domain)
+        - stop - says if threads were told to stop by file flag
+        - in_heap - marks if domain is in the heap
+        - downloads_waiting - marks downloads waiting craler to finish
+        - lock - lock to access variables above
+        """
+        domain_to_key = {}
+
+        for item in FileDownloader.download_source(testing):
+            print(f"internal_producer  - received {type(item)} {item}")
+            item = json.loads(item)
+            if item["destination"][-1] != "/":
+                item["destination"] = item["destination"] + "/"
+
+            print("waiting lock")
+            with lock:
+                print("got lock")
+                domain = crawling_utils.get_url_domain(item["url"])
+
+                if domain not in domain_to_key:
+                    key = len(domain_to_key)
+                    domain_to_key[domain] = key
+                    wait_line[key] = queue.Queue()
+                    in_heap[key] = False
+
+                key = domain_to_key[domain]
+
+                item = FileDownloader.log_item(item) # gets item id on db
+                wait_line[key].put(item)
+                if item["wait_crawler_finish_to_download"]:
+                    print(
+                        "internal_producer  - item should wait " \
+                        "crawler to finish"
+                    )
+                    downloads_waiting.add((key, item["crawler_id"]))
+                elif wait_line[key].qsize() == 1 and not in_heap[key]:
+                    print("internal_producer  - insertind on heap")
+                    heapq.heappush(heap, (1, key))
+                else:
+                    print(
+                        "internal_producer  - this domain " \
+                        "already has itens on heap"
+                    )
+                
+                size = wait_line[key].qsize()
+                print(f"internal_producer - Received: {item['url']}")
+                print(f"internal_producer - Domain key: {key}")
+                print(f"internal_producer - Domain wait line size: {size}")
+                print(f"internal_producer - heap: {heap}")
+        
+        with lock:
+            stop = True
+        
+    @staticmethod
+    def downloads_waiting_crawl_end(
+        wait_line, heap, stop, in_heap, 
+        downloads_waiting, lock
+    ):
+        """
+        Keeps track of downloads that must wait for the crawler to finish.
+        Check for these every 60 seconds.
+        - wait_line - list of itens to download by domain
+        - heap - min heap of (last access, domain)
+        - stop - says if threads were told to stop by file flag
+        - in_heap - marks if domain is in the heap
+        - downloads_waiting - marks downloads waiting craler to finish
+        - lock - lock to access variables above
+        """
+        detail_url = "http://localhost:8000/api/crawlers/"
+        local_stop = False
+        while not local_stop:
+            must_check = []
+            with lock:
+                for (key, cralwer_id) in downloads_waiting:
+                    must_check.append({
+                        "key": key,
+                        "crawler_id": cralwer_id,
+                    })
+
+            print(
+                "downloads_waiting_crawl_end",
+                "- downloads waiting:",
+                must_check
+            )
+
+            crawlers_done = []
+            for i in must_check:
+                crawler = requests.get(detail_url + str(i['crawler_id']) + "/")
+                if crawler.json()["running"] == False:
+                    crawlers_done.append(i)
+            
+            print("downloads_waiting_crawl_end - crawlers_done:", must_check)
+
+            with lock:
+                for i in crawlers_done:
+                    downloads_waiting.remove((i["key"], i["crawler_id"]))
+                    # if this file was discovered after the crawler
+                    # finished, we want to avoid inserting it again
+                    # in the heap
+                    if not in_heap[i["key"]]:
+                        heapq.heappush(heap, (time.time() + 60, i["key"]))
+                        print(
+                            "downloads_waiting_crawl_end - inserting on heap:",
+                            i
+                        )
+                local_stop = stop
+
+            time.sleep(60)
+
+    @staticmethod
+    def download_consumer(testing=False):
         """
         Download items from FileDownloader.download_source.
         Items must be json strings of dictionaries containing the following
@@ -113,41 +331,48 @@ class FileDownloader(BaseMessenger):
             f"Starting file downloader at", 
             datetime.datetime.now().isoformat()
         )
-        for item in FileDownloader.download_source(testing):
-            if item["destination"][-1] != "/":
-                item["destination"] = item["destination"] + "/"
+        wait_line = {} # list of itens to download by domain
+        heap = [] # min heap of (last access, domain)
+        stop = False # says if threads were told to stop by file flag
+        in_heap = {} # marks if domain is in the heap
+        downloads_waiting = set() # marks downloads waiting craler to finish
+        lock = threading.Lock() # lock to access variables above
 
-            success = False
-            error_message = ""
-            for attempt in range(1, max_attempts + 1):
-                print(
-                    "Trying to download file "
-                    f"(attempt {attempt}/{max_attempts}): ",
-                    item["url"]
-                )
-                try:
-                    FileDownloader.download_file(item)
-                    print("Downloaded", item["url"], "successfully.")
-                    success = True
+        threads = []
 
-                    FileDownloader.convert_binary(item)
-                    break
-                except Exception as e:
-                    print(
-                        f"{attempt}-th attempt to download \"{item['url']}\" "
-                        f"failed. Error message: {str(type(e))}-{e}"
-                    )
-                    error_message = str(e)
+        threads.append(threading.Thread(
+            target=FileDownloader.internal_consumer,
+            args=(
+                wait_line, heap, stop, in_heap, 
+                downloads_waiting, lock,
+            ),
+            daemon=True, # will be killed if only deamon threads are running
+        ))
 
-            if not success:
-                print("All attempts to download", item["url"], "failed.")
-                response = requests.put(
-                    f'http://localhost:8000/api/downloads/{item["id"]}/',
-                    data={
-                        "status": "ERROR",
-                        "error_message": error_message
-                    }
-                )
+        threads.append(threading.Thread(
+            target=FileDownloader.downloads_waiting_crawl_end,
+            args=(
+                wait_line, heap, stop, in_heap, 
+                downloads_waiting, lock,
+            ),
+            daemon=True, # will be killed if only deamon threads are running
+        ))
+
+        threads.append(threading.Thread(
+            target=FileDownloader.internal_producer,
+            args=(
+                wait_line, heap, stop, in_heap, 
+                downloads_waiting, lock,
+                testing
+            ),
+            daemon=True, # will be killed if only deamon threads are running
+        ))
+
+        for t in threads:
+            t.start()
+
+        for t in threads:
+            t.join()
 
     @staticmethod
     def download_file(item):
@@ -195,7 +420,6 @@ class FileDownloader(BaseMessenger):
                 "progress": current
             }
         )
-        print()
 
     @staticmethod
     def log_item(item):
@@ -204,9 +428,8 @@ class FileDownloader(BaseMessenger):
             'http://localhost:8000/api/downloads/',
             data={
                 "status": "WAITING",
-                "description": item,
+                "description": json.dumps(item),
             }
         )
-        item = json.loads(item)
         item["id"] = response.json()["id"]
         return item

--- a/main/forms.py
+++ b/main/forms.py
@@ -50,6 +50,8 @@ class CrawlRequestForm(forms.ModelForm):
             'download_files_allow_url',
             'download_files_allow_extensions',
             'download_imgs',
+            'wait_crawler_finish_to_download',
+            'time_between_downloads',
             'steps',
             'save_csv',
             'table_attrs',
@@ -266,6 +268,14 @@ class RawCrawlRequestForm(CrawlRequestForm):
 
     download_imgs = forms.BooleanField(
         required=False, label="Baixar imagens")
+
+    wait_crawler_finish_to_download = forms.BooleanField(
+        required=False, label="Esperar coletor finalizar para baixar arquivos")
+
+    time_between_downloads = forms.IntegerField(
+        required=False,
+        label="Tempo entre requisições de download de arquivos",
+    )
 
     # Crawler Type - Page with form
     steps = forms.CharField(required=False, label="Steps JSON", max_length=9999999,

--- a/main/models.py
+++ b/main/models.py
@@ -124,7 +124,8 @@ class CrawlRequest(TimeStamped):
     download_imgs = models.BooleanField(default=False)
 
     wait_crawler_finish_to_download = models.BooleanField(default=False)
-    time_between_downloads = models.IntegerField(default=60)
+    time_between_downloads = models.IntegerField(
+        blank=True, null=True, default=60)
 
     steps = models.CharField(
         blank=True, null=True, max_length=9999999, default='{}')

--- a/main/models.py
+++ b/main/models.py
@@ -124,8 +124,7 @@ class CrawlRequest(TimeStamped):
     download_imgs = models.BooleanField(default=False)
 
     wait_crawler_finish_to_download = models.BooleanField(default=False)
-    time_between_downloads = models.IntegerField(
-        blank=True, null=True, default=60)
+    time_between_downloads = models.IntegerField(default=60)
 
     steps = models.CharField(
         blank=True, null=True, max_length=9999999, default='{}')

--- a/main/models.py
+++ b/main/models.py
@@ -123,6 +123,9 @@ class CrawlRequest(TimeStamped):
 
     download_imgs = models.BooleanField(default=False)
 
+    wait_crawler_finish_to_download = models.BooleanField(default=False)
+    time_between_downloads = models.IntegerField(default=60)
+
     steps = models.CharField(
         blank=True, null=True, max_length=9999999, default='{}')
 

--- a/main/models.py
+++ b/main/models.py
@@ -124,7 +124,7 @@ class CrawlRequest(TimeStamped):
     download_imgs = models.BooleanField(default=False)
 
     wait_crawler_finish_to_download = models.BooleanField(default=False)
-    time_between_downloads = models.IntegerField(default=60)
+    time_between_downloads = models.IntegerField(blank=True, null=True)
 
     steps = models.CharField(
         blank=True, null=True, max_length=9999999, default='{}')

--- a/main/templates/main/create_crawler.html
+++ b/main/templates/main/create_crawler.html
@@ -261,8 +261,18 @@ New Crawler
                                         {{ form.download_files_allow_url | as_crispy_field}}
                                         {{ form.download_files_allow_extensions | as_crispy_field}}
                                     </div>
-                                    <div id="download_files" style="padding:20px; border-top: 1px solid #DCDCDC;">
+                                    <div id="download_img" style="padding:20px; border-top: 1px solid #DCDCDC;">
                                         {{ form.download_imgs | as_crispy_field}}
+                                    </div>
+                                    <div id="wait_crawler_finish_to_download" style="padding:20px; border-top: 1px solid #DCDCDC;">
+                                        <p>
+                                            Alguns servidores podem cancelar o download se outras requisições forem feitas ao mesmo tempo,
+                                            ou se um download for feito atrás do outro. Se os downloads começarem a dar erro com a mensagem
+                                            <i>"Foi forçado o cancelamento de uma conexão existente pelo host remoto"</i> ou mensagens 
+                                            parecidas, alterar estes valores pode ajudar.
+                                        </p>
+                                        {{ form.wait_crawler_finish_to_download | as_crispy_field }}
+                                        {{ form.time_between_downloads | as_crispy_field }}
                                     </div>
                                 </div>
                                 <div class="crawler-type-content-div" id="form_page" hidden>

--- a/main/templates/main/downloads.html
+++ b/main/templates/main/downloads.html
@@ -22,6 +22,17 @@ Downloads
 <div class="row">
     <div class="col-2"></div>
     <div class="col">
+        Alguns downloads podem continuar na fila mesmo se não houver nenhum
+        download sendo feito. Isso acontece pois temos que respeitar o tempo
+        entre requisições a um mesmo domínio e um coletor pode estar 
+        configurado para baixar arquivos só depois que a coleta terminar.
+    </div>
+    <div class="col-2"></div>
+</div>
+
+<div class="row">
+    <div class="col-2"></div>
+    <div class="col">
         <div class="row"><div class="col"><h5>Na fila: </h5></div></div>
         <div class="row"><div id="file_queue" class="col"></div></div>
     </div>


### PR DESCRIPTION
O FileDownloader não vai mais baixar os arquivos na ordem que eles são retornados necessariamente. Adicionei 2 configurações aos coletores: 1) se devemos esperar o coletor acabar para começar downloads; 2) tempo entre requisições de download de uma coleta.

Fiz isso pois estava tendo muitos problemas com a coleta da issue #292. O servidor interrompia o download se outra requisição fosse mandada pra ele, e se eu fizesse muitas seguidas ele cancelava o download também.

O código ficou um pouco complicado. Adicionei 3 threads ao file_downloader:
1) internal_producer - recebe os itens para serem baixados, e chega se ja devem ser baixados. Se sim, anota as urls de um dominio numa fila e o dominio em um heap
2) internal_consumer - confere se tem dominios no heap e se ja pode baixar o primeiro dominio. Faz download e atualiza ultimo acesso ao dominio.
3) wait_line - cuida dos downloads que tem que esperar a coleta acabar. Ele manda requisições pra endpoint de informações sobre o coletor a cada minuto conferindo se o coletor acabou. Quando a coleta acaba ele insere o dominio no heap pra começar o download.

close #295 