### PR TITLE
Issue 316 - Adiciona download em memória para arquivos pequenos

### DIFF
--- a/crawlers/file_downloader.py
+++ b/crawlers/file_downloader.py
@@ -227,6 +227,7 @@ class FileDownloader(BaseMessenger):
                 print(f"re-building heap: {heap}")
                 local_stop = stop
 
+    @staticmethod
     def internal_producer(
         wait_line, heap, stop, in_heap,
         downloads_waiting, lock,

--- a/crawlers/file_downloader.py
+++ b/crawlers/file_downloader.py
@@ -7,6 +7,7 @@ import heapq
 import queue
 import threading
 import time
+import subprocess
 
 # Project libs
 import binary
@@ -166,8 +167,8 @@ class FileDownloader(BaseMessenger):
         # downloads may create *.tmp files and leave them here.
         try:
             subprocess.run(["rm", "*.tmp"])
-        except:
-            pass
+        except Exception as e:
+            print(f"Cannot clean tmp files: {str(type(e))}-{e}")
 
     @staticmethod
     def internal_consumer(

--- a/crawlers/file_downloader.py
+++ b/crawlers/file_downloader.py
@@ -214,7 +214,7 @@ class FileDownloader(BaseMessenger):
             FileDownloader.process_item(item)
 
             if item["time_between_downloads"] is None:
-                add = 60
+                add = 1
             else:
                 add = item["time_between_downloads"]
             next_download = int(time.time()) + add

--- a/crawlers/file_downloader.py
+++ b/crawlers/file_downloader.py
@@ -163,6 +163,12 @@ class FileDownloader(BaseMessenger):
                 }
             )
 
+        # downloads may create *.tmp files and leave them here.
+        try:
+            subprocess.run(["rm", "*.tmp"])
+        except:
+            pass
+
     @staticmethod
     def internal_consumer(
         wait_line, heap, stop, in_heap,

--- a/crawlers/static_page.py
+++ b/crawlers/static_page.py
@@ -56,9 +56,9 @@ class StaticPageSpider(BaseSpider):
         """Filter a list of urls according to a regex pattern."""
         def allow(url):
             if (re.search(pattern, url) is not None):
-                print(f"ADDING link (passed regex filter) - {url}")
+                # print(f"ADDING link (passed regex filter) - {url}")
                 return True
-            print(f"DISCARDING link (filtered by regex) - {url}")
+            # print(f"DISCARDING link (filtered by regex) - {url}")
             return False
 
         urls_filtered = set(filter(allow, url_list))
@@ -70,9 +70,9 @@ class StaticPageSpider(BaseSpider):
         def allow(url):
             req_head = requests.head(url).headers['Content-Type']
             if (head in req_head):
-                print(f"ADDING link (correct type) - {url}")
+                # print(f"ADDING link (correct type) - {url}")
                 return True
-            print(f"DISCARDING link (incorrect type) - {url}")
+            # print(f"DISCARDING link (incorrect type) - {url}")
             return False
 
         urls_filtered = set(filter(allow, url_list))
@@ -95,6 +95,8 @@ class StaticPageSpider(BaseSpider):
             urls_found = self.filter_list_of_urls(urls_found, pattern)
 
         urls_found = self.filter_type_of_urls(urls_found, 'text/html')
+
+        print("Links kept: ", urls_found)
 
         return urls_found
 
@@ -120,6 +122,8 @@ class StaticPageSpider(BaseSpider):
             urls_found, r"(.*\.[a-z]{3,4}$)(.*(?<!\.html)$)(.*(?<!\.php)$)")
 
         urls_found = urls_found_a.union(urls_found_b)
+
+        print("Files kept: ", urls_found)
 
         return urls_found
 

--- a/run.py
+++ b/run.py
@@ -55,11 +55,6 @@ def signal_stop(e):
 def run():
     global stop_processes, process_exception, n_processes_running, global_lock
 
-    try:
-        subprocess.run(["rm", "*.tmp"])
-    except:
-        pass
-
     print("Initializing processes")
     pool = multiprocessing.Pool(
         processes=N_FUNCTIONS,

--- a/run.py
+++ b/run.py
@@ -55,6 +55,11 @@ def signal_stop(e):
 def run():
     global stop_processes, process_exception, n_processes_running, global_lock
 
+    try:
+        subprocess.run(["rm", "*.tmp"])
+    except:
+        pass
+
     print("Initializing processes")
     pool = multiprocessing.Pool(
         processes=N_FUNCTIONS,

--- a/src/crawling_utils/crawling_utils/crawling_utils.py
+++ b/src/crawling_utils/crawling_utils/crawling_utils.py
@@ -4,6 +4,30 @@ import time
 import hashlib
 import os
 from urllib.parse import urlparse
+import wget
+
+class StopDownload(Exception):
+    """Used in func file_larger_than_giga"""
+    pass
+
+def file_larger_than_giga(url):
+    """
+    True if file has more than 1e9 bytes.
+    Request a single block from url and check its size.
+    """
+    save = {"url": url}
+
+    def get_size(current, total, widht=None):
+        save["total_size"] = total
+        raise StopDownload
+
+    try:
+        wget.download(url, bar=get_size)
+    except StopDownload:
+        pass
+
+    # total_size is in bytes
+    return save["total_size"] > 1e9
 
 
 def get_url_domain(url):
@@ -12,11 +36,9 @@ def get_url_domain(url):
     return result
 
 
-
 def hash(byte_content):
     """Returns the md5 hash of a bytestring."""
     return hashlib.md5(byte_content).hexdigest()
-
 
 # leave as 'chromedriver' if driver is on path
 CHROME_WEBDRIVER_PATH = 'chromedriver'

--- a/src/crawling_utils/crawling_utils/crawling_utils.py
+++ b/src/crawling_utils/crawling_utils/crawling_utils.py
@@ -6,9 +6,11 @@ import os
 from urllib.parse import urlparse
 import wget
 
+
 class StopDownload(Exception):
     """Used in func file_larger_than_giga"""
     pass
+
 
 def file_larger_than_giga(url):
     """


### PR DESCRIPTION
 A solução com wget para download de arquivos funciona corretamente, mas na maioria dos casos testados os servidores começam a diminuir a velocidade de resposta para o wget. Então quando vamos coletar uma página com muitos arquivos pequenos, a coleta fica muito mais lenta do que seria se feita somente com o scrapy. 

Adicionei uma funcionalidade ao file_downloader. Agora ele checa o tamanho do arquivo e, se for menor do que 1GB, ele baixa o arquivo em uma requisição só e escreve ele em disco depois. Caso contrário o download ainda é feito em blocos direto para o disco wget.download.

close #316 