### PR TITLE
Issue 315 - Conserta conversão de binários no file_downloader e extract_csv no base_spider

### DIFF
--- a/crawlers/base_spider.py
+++ b/crawlers/base_spider.py
@@ -340,15 +340,17 @@ class BaseSpider(scrapy.Spider):
 
         success = False
         try:
-            if self.config["table_attrs"] is None or self.config["table_attrs"] == "":
+            table_attrs = config["table_attrs"]
+            if table_attrs is None or table_attrs == "":
                 parsing_html.content.html_detect_content(
                     description["relative_path"],
                     is_string=False,
                     output_file=output_filename,
-                    to_csv=self.config["save_csv"]
+                    to_csv=config["save_csv"]
                 )
             else:
-                extra_config = self.extra_config_parser(self.config["table_attrs"])
+                extra_config = self.extra_config_parser(
+                    config["table_attrs"])
                 parsing_html.content.html_detect_content(
                     description["relative_path"],
                     is_string=False, output_file=output_filename,
@@ -365,7 +367,7 @@ class BaseSpider(scrapy.Spider):
                     na_values=extra_config['table_na_values'],
                     keep_default_na=extra_config['table_default_na'],
                     displayed_only=extra_config['table_displayed_only'],
-                    to_csv=self.config["save_csv"]
+                    to_csv=config["save_csv"]
                 )
             success = True
 

--- a/crawlers/crawler_manager.py
+++ b/crawlers/crawler_manager.py
@@ -33,16 +33,16 @@ from crawlers.static_page import StaticPageSpider
 def file_downloader_process():
     """Redirects downloader output and starts downloader consumer loop."""
     crawling_utils.check_file_path("crawlers/log/")
-    sys.stdout = open(f"crawlers/log/file_downloader.out", "a", buffering=1)
-    sys.stderr = open(f"crawlers/log/file_downloader.err", "a", buffering=1)
+    sys.stdout = open(f"crawlers/log/file_downloader.out", "w+", buffering=1)
+    sys.stderr = open(f"crawlers/log/file_downloader.err", "w+", buffering=1)
     FileDownloader.download_consumer()
 
 
 def file_descriptor_process():
     """Redirects descriptor output and starts descriptor consumer loop."""
     crawling_utils.check_file_path("crawlers/log/")
-    sys.stdout = open(f"crawlers/log/file_descriptor.out", "a", buffering=1)
-    sys.stderr = open(f"crawlers/log/file_descriptor.err", "a", buffering=1)
+    sys.stdout = open(f"crawlers/log/file_descriptor.out", "w+", buffering=1)
+    sys.stderr = open(f"crawlers/log/file_descriptor.err", "w+", buffering=1)
     FileDescriptor.description_consumer()
 
 

--- a/crawlers/file_downloader.py
+++ b/crawlers/file_downloader.py
@@ -157,8 +157,8 @@ class FileDownloader(BaseMessenger):
                 print("Downloaded", item["url"], "successfully.")
                 success = True
 
-                extracted_files = FileDownloader.convert_binary(item)
-                item["extracted_files"] = extracted_files
+                extracted_files = FileDownloader.convert_binary(item.copy())
+                item['description']["extracted_files"] = extracted_files
 
                 FileDescriptor.feed_description(
                     item['destination'] + "files/", item['description'])

--- a/src/binary_extractor/binary/binary_extractor.py
+++ b/src/binary_extractor/binary/binary_extractor.py
@@ -43,8 +43,6 @@ class BinaryExtractor():
         pure = Path(self.path)
         self.name = pure.stem
         self.directory = pure.parents[1].joinpath('csv/' + self.name)
-        Path.mkdir(self.directory, exist_ok=True)
-
         # file parsing
         try:
             self.open = parser.from_file(self.path)
@@ -78,7 +76,7 @@ class BinaryExtractor():
             name (str): name of the csv file.
 
         """
-
+        Path.mkdir(self.directory, exist_ok=True)
         file = self.directory.joinpath(name + '.csv')
         with open(file, 'w') as out:
             dataframe.to_csv(out, encoding='utf-8', index=None)


### PR DESCRIPTION
A parte do código do file_downloader que tentava extrair as tabelas dos pdfs não estava funcionando. Agora o file_downloader vai criar um arquivo para cada tabela no pdf, e para manter tudo conectado, adicionei dois atributos ao file_description: extracted_from (no caso dos csvs) e extracted_files (no caso dos arquivos originais). Para seguir o padrão, adicionei isso aos csvs dos htmls também, mas descobri que o extrator de csvs dos htmls nunca estava funcionando e então corrigi a função.

close #315 