### PR TITLE
Issue 315 - Adiciona configurações avançadas para descoberta de links e download de arquivos

### DIFF
--- a/crawlers/file_downloader.py
+++ b/crawlers/file_downloader.py
@@ -79,10 +79,11 @@ class FileDownloader(BaseMessenger):
         - description: dict, dictionary of item descriptions
         """
 
-        if item["type"] != "pdf":
+        item_desc = item["description"].copy()
+
+        if item_desc["type"] != "pdf":
             return
 
-        item_desc = item["description"].copy()
         url_hash = crawling_utils.hash(item["url"].encode())
         source_file = f"{item['destination']}files/{item_desc['file_name']}"
 

--- a/crawlers/file_downloader.py
+++ b/crawlers/file_downloader.py
@@ -79,6 +79,9 @@ class FileDownloader(BaseMessenger):
         - description: dict, dictionary of item descriptions
         """
 
+        if item["type"] != "pdf":
+            return
+
         item_desc = item["description"].copy()
         url_hash = crawling_utils.hash(item["url"].encode())
         source_file = f"{item['destination']}files/{item_desc['file_name']}"

--- a/crawlers/static_page.py
+++ b/crawlers/static_page.py
@@ -19,8 +19,6 @@ class StaticPageSpider(BaseSpider):
     def start_requests(self):
         print("At StaticPageSpider.start_requests")
 
-        self.convert_allow_extesions()
-
         for req in self.generate_initial_requests():
 
             # Don't send an empty dict, may cause spider to be blocked
@@ -38,19 +36,22 @@ class StaticPageSpider(BaseSpider):
             },
                 errback=self.errback_httpbin)
 
-    def convert_allow_extesions(self):
+    def convert_allow_extesions(self, config):
         """Converts 'allow_extesions' configuration into 'deny_extesions'."""
-        allow_extension = f"download_files_allow_extensions"
+        allow = "download_files_allow_extensions"
+        deny = "donwload_files_deny_extensions"
         if (
-            allow_extension in self.config and
-            self.config[allow_extension] is not None and
-            self.config[allow_extension] != ""
+            allow in config and
+            config[allow] is not None and
+            config[allow] != "" and
+            deny not in config
         ):
-            allowed_extensions = set(self.config[allow_extension].split(","))
+            allowed_extensions = set(config[allow].split(","))
             extensions = [i for i in scrapy.linkextractors.IGNORED_EXTENSIONS]
-            self.config[f"donwload_files_deny_extensions"] = [
+            config[deny] = [
                 i for i in extensions if i not in allowed_extensions
             ]
+        return config
 
     def filter_list_of_urls(self, url_list, pattern):
         """Filter a list of urls according to a regex pattern."""
@@ -81,14 +82,41 @@ class StaticPageSpider(BaseSpider):
 
         return urls_filtered
 
+    def preprocess_listify(self, value, default):
+        """Converts a string of ',' separaded values into a list."""
+        if value is None or len(value) == 0:
+            value = default
+        elif type(value) == str:
+            value = tuple(value.split(","))
+        return value
+
+    def preprocess_link_configs(self, config):
+        """Process link_extractor configurations."""
+        if "link_extractor_processed" in config:
+            return config
+
+        defaults = [
+            ("link_extractor_tags", ('a', 'area')),
+            ("link_extractor_allow_domains", None),
+            ("link_extractor_attrs", ('href',))
+        ]
+        for attr, default in defaults:
+            config[attr] = self.preprocess_listify(config[attr], default)
+
+        config["link_extractor_processed"] = True
+
+        return config
+
     def extract_links(self, response):
         """Filter and return a set with links found in this response."""
-
-        config = response.meta['config']
-        # TODO: cant make regex tested on https://regexr.com/ work
-        # here for some reason
-        links_extractor = LinkExtractor()
-        #    allow=self.config["link_extractor_allow_url"])
+        config = self.preprocess_link_configs(response.meta["config"])
+        
+        links_extractor = LinkExtractor(
+            allow_domains=config["link_extractor_allow_domains"],
+            tags=config["link_extractor_tags"],
+            attrs=config["link_extractor_attrs"],
+            process_value=config["link_extractor_process_value"],
+        )
 
         urls_found = {i.url for i in links_extractor.extract_links(response)}
 
@@ -96,30 +124,58 @@ class StaticPageSpider(BaseSpider):
         if pattern != "":
             urls_found = self.filter_list_of_urls(urls_found, pattern)
 
-        urls_found = self.filter_type_of_urls(urls_found, True)
+        if config["link_extractor_check_type"]:
+            urls_found = self.filter_type_of_urls(urls_found, True)
 
         print("Links kept: ", urls_found)
 
         return urls_found
 
+    def preprocess_download_configs(self, config):
+        """Process download_files configurations."""
+        if "download_files_processed" in config:
+            return config
+
+        defaults = [
+            ("download_files_tags", ('a', 'area')),
+            ("download_files_allow_domains", None),
+            ("download_files_attrs", ('href',))
+        ]
+        for attr, default in defaults:
+            config[attr] = self.preprocess_listify(config[attr], default)
+
+        config = self.convert_allow_extesions(config)
+
+        attr = "download_files_process_value"
+        if config[attr] is not None and type(config[attr]) is str:
+            config[attr] = eval(config[attr])
+
+        config["download_files_processed"] = True
+
+        return config
+
     def extract_files(self, response):
         """Filter and return a set with links found in this response."""
-        config = response.meta['config']
-        # TODO: cant make regex tested on https://regexr.com/ work
-        # here for some reason
+        config = self.preprocess_download_configs(response.meta["config"])
+    
         links_extractor = LinkExtractor(
-            deny_extensions=self.config["donwload_files_deny_extensions"]
-            #    allow = self.config["download_files_allow_url"], ())
+            allow_domains=config["download_files_allow_domains"],
+            tags=config["download_files_tags"],
+            attrs=config["download_files_attrs"],
+            process_value=config["download_files_process_value"],
+            deny_extensions=config["donwload_files_deny_extensions"]
         )
         urls_found = {i.url for i in links_extractor.extract_links(response)}
-
+        
         pattern = config["download_files_allow_url"]
 
         if pattern != "":
             urls_found = self.filter_list_of_urls(urls_found, pattern)
 
-        urls_found_a = self.filter_type_of_urls(urls_found, False)
-
+        urls_found_a = set()
+        if config["download_files_check_type"]:
+            urls_found_a = self.filter_type_of_urls(urls_found, False)
+            
         urls_found_b = self.filter_list_of_urls(
             urls_found, r"(.*\.[a-z]{3,4}$)(.*(?<!\.html)$)(.*(?<!\.php)$)")
 

--- a/crawlers/static_page.py
+++ b/crawlers/static_page.py
@@ -110,7 +110,7 @@ class StaticPageSpider(BaseSpider):
     def extract_links(self, response):
         """Filter and return a set with links found in this response."""
         config = self.preprocess_link_configs(response.meta["config"])
-        
+
         links_extractor = LinkExtractor(
             allow_domains=config["link_extractor_allow_domains"],
             tags=config["link_extractor_tags"],
@@ -157,7 +157,7 @@ class StaticPageSpider(BaseSpider):
     def extract_files(self, response):
         """Filter and return a set with links found in this response."""
         config = self.preprocess_download_configs(response.meta["config"])
-    
+
         links_extractor = LinkExtractor(
             allow_domains=config["download_files_allow_domains"],
             tags=config["download_files_tags"],
@@ -166,7 +166,7 @@ class StaticPageSpider(BaseSpider):
             deny_extensions=config["donwload_files_deny_extensions"]
         )
         urls_found = {i.url for i in links_extractor.extract_links(response)}
-        
+
         pattern = config["download_files_allow_url"]
 
         if pattern != "":
@@ -175,7 +175,7 @@ class StaticPageSpider(BaseSpider):
         urls_found_a = set()
         if config["download_files_check_type"]:
             urls_found_a = self.filter_type_of_urls(urls_found, False)
-            
+
         urls_found_b = self.filter_list_of_urls(
             urls_found, r"(.*\.[a-z]{3,4}$)(.*(?<!\.html)$)(.*(?<!\.php)$)")
 

--- a/main/forms.py
+++ b/main/forms.py
@@ -254,15 +254,18 @@ class RawCrawlRequestForm(CrawlRequestForm):
     link_extractor_allow_url = forms.CharField(
         required=False, max_length=2000,
         label=(
-            "Permitir urls que casem com o regex"
-            " (deixe em branco para não filtrar):"
+            "Permitir urls que casem com o regex:"
+            " (deixe em branco para não filtrar)"
         ),
         widget=forms.TextInput(
             attrs={'placeholder': 'Regex para permitir urls'})
     )
     link_extractor_allow_domains = forms.CharField(
         required=False, max_length=2000,
-        label="Permitir só urls dos domínios: (em branco para não filtrar)",
+        label=(
+            "Permitir só urls dos domínios:"
+            "(em branco para não filtrar) (separado por vírgula)"
+        ),
         widget=forms.TextInput(
             attrs={'placeholder': ''})
     )
@@ -296,8 +299,8 @@ class RawCrawlRequestForm(CrawlRequestForm):
     download_files_allow_url = forms.CharField(
         required=False, max_length=2000,
         label=(
-            "Baixar arquivos de url que casem com o regex"
-            " (deixe em branco para não filtrar):"
+            "Baixar arquivos de url que casem com o regex:"
+            " (deixe em branco para não filtrar)"
         ),
         widget=forms.TextInput(
             attrs={'placeholder': 'Regex para permitir urls'})
@@ -309,7 +312,10 @@ class RawCrawlRequestForm(CrawlRequestForm):
     )
     download_files_allow_domains = forms.CharField(
         required=False, max_length=2000,
-        label="Permitir só urls dos domínios: (em branco para não filtrar)",
+        label=(
+            "Permitir só urls dos domínios:"
+            "(em branco para não filtrar) (separado por vírgula)"
+        ),
         widget=forms.TextInput(
             attrs={'placeholder': ''})
     )

--- a/main/forms.py
+++ b/main/forms.py
@@ -45,11 +45,24 @@ class CrawlRequestForm(forms.ModelForm):
             'sound_xpath',
             'crawler_type',
             'explore_links',
+
             'link_extractor_max_depth',
             'link_extractor_allow_url',
+            'link_extractor_allow_domains',
+            'link_extractor_tags',
+            'link_extractor_attrs',
+            'link_extractor_check_type',
+            'link_extractor_process_value',
+
             'download_files',
             'download_files_allow_url',
+            'download_files_allow_domains',
+            'download_files_tags',
+            'download_files_attrs',
+            'download_files_check_type',
+            'download_files_process_value',
             'download_files_allow_extensions',
+
             'download_imgs',
             'wait_crawler_finish_to_download',
             'time_between_downloads',
@@ -247,10 +260,39 @@ class RawCrawlRequestForm(CrawlRequestForm):
         widget=forms.TextInput(
             attrs={'placeholder': 'Regex para permitir urls'})
     )
+    link_extractor_allow_domains = forms.CharField(
+        required=False, max_length=2000,
+        label="Permitir só urls dos domínios: (em branco para não filtrar)",
+        widget=forms.TextInput(
+            attrs={'placeholder': ''})
+    )
+    link_extractor_tags = forms.CharField(
+        required=False, max_length=2000,
+        label="Extrair links de tags do tipo: (separado por vírgula)",
+        widget=forms.TextInput(
+            attrs={'placeholder': 'a'})
+    )
+    link_extractor_attrs = forms.CharField(
+        required=False, max_length=2000,
+        label="Extrair urls dos atributos: (separado por vírgula)",
+        widget=forms.TextInput(
+            attrs={'placeholder': 'href'})
+    )
+    link_extractor_check_type = forms.BooleanField(
+        required=False, label="Checar tipo da página")
+    link_extractor_process_value = forms.CharField(
+        required=False, max_length=2000,
+        label=(
+            "Função python para processar os atributos: "
+            "(A função será chamada como 'eval(func)(attr)')"
+        ),
+        widget=forms.Textarea(
+            attrs={'placeholder': 'lambda x: x'})
+    )
 
     download_files = forms.BooleanField(
-        required=False, label="Baixar arquivos")
-
+        required=False, label="Baixar arquivos"
+    )
     download_files_allow_url = forms.CharField(
         required=False, max_length=2000,
         label=(
@@ -260,11 +302,39 @@ class RawCrawlRequestForm(CrawlRequestForm):
         widget=forms.TextInput(
             attrs={'placeholder': 'Regex para permitir urls'})
     )
-
     download_files_allow_extensions = forms.CharField(
         required=False, max_length=2000,
         label="Extensões de arquivo permitidas (separado por vírgula):",
         widget=forms.TextInput(attrs={'placeholder': 'pdf,xml'})
+    )
+    download_files_allow_domains = forms.CharField(
+        required=False, max_length=2000,
+        label="Permitir só urls dos domínios: (em branco para não filtrar)",
+        widget=forms.TextInput(
+            attrs={'placeholder': ''})
+    )
+    download_files_tags = forms.CharField(
+        required=False, max_length=2000,
+        label="Extrair links de tags do tipo: (separado por vírgula)",
+        widget=forms.TextInput(
+            attrs={'placeholder': 'a'})
+    )
+    download_files_attrs = forms.CharField(
+        required=False, max_length=2000,
+        label="Extrair urls dos atributos: (separado por vírgula)",
+        widget=forms.TextInput(
+            attrs={'placeholder': 'href'})
+    )
+    download_files_check_type = forms.BooleanField(
+        required=False, label="Checar tipo da página")
+    download_files_process_value = forms.CharField(
+        required=False, max_length=2000,
+        label=(
+            "Função python para processar os atributos: "
+            "(A função será chamada como 'eval(func)(attr)')"
+        ),
+        widget=forms.Textarea(
+            attrs={'placeholder': 'lambda x: x'})
     )
 
     download_imgs = forms.BooleanField(

--- a/main/models.py
+++ b/main/models.py
@@ -114,13 +114,41 @@ class CrawlRequest(TimeStamped):
     explore_links = models.BooleanField(blank=True, null=True)
     link_extractor_max_depth = models.IntegerField(blank=True, null=True)
     link_extractor_allow_url = models.CharField(
-        max_length=1000, blank=True, null=True)
+        max_length=1000, blank=True, null=True
+    )
+    link_extractor_allow_domains = models.CharField(
+        max_length=1000, blank=True, null=True
+    )
+    link_extractor_tags = models.CharField(
+        max_length=1000, blank=True, null=True
+    )
+    link_extractor_attrs = models.CharField(
+        max_length=1000, blank=True, null=True
+    )
+    link_extractor_check_type = models.BooleanField(blank=True, null=True)
+    link_extractor_process_value = models.TextField(
+        max_length=1000, blank=True, null=True
+    )
 
     download_files = models.BooleanField(blank=True, null=True)
     download_files_allow_url = models.CharField(
         max_length=1000, blank=True, null=True)
     download_files_allow_extensions = models.CharField(
         blank=True, null=True, max_length=2000)
+    download_files_allow_domains = models.CharField(
+        max_length=1000, blank=True, null=True
+    )
+    download_files_tags = models.CharField(
+        max_length=1000, blank=True, null=True
+    )
+    download_files_attrs = models.CharField(
+        max_length=1000, blank=True, null=True
+    )
+    download_files_check_type = models.BooleanField(blank=True, null=True)
+    download_files_process_value = models.TextField(
+        max_length=1000, blank=True, null=True
+    )
+
 
     download_imgs = models.BooleanField(default=False)
 

--- a/main/staticfiles/css/style.css
+++ b/main/staticfiles/css/style.css
@@ -1,3 +1,7 @@
+*, ::after, ::before {
+    box-sizing: border-box;
+}
+
 .navbar{
     background-color: #286f99;
 }
@@ -18,6 +22,7 @@ body {
     margin-left:0;
     margin-right:0;
 }
+
 #sidebar-container {
     min-height: 89vh;
     background-color: #333;
@@ -28,6 +33,7 @@ body {
 .sidebar-expanded {
     width: 230px;
 }
+
 .sidebar-collapsed {
     width: 60px;
 }
@@ -47,6 +53,7 @@ body {
     height: 45px;
     padding-left: 30px;
 }
+
 .sidebar-submenu {
     font-size: 0.9rem;
 }
@@ -56,10 +63,12 @@ body {
     background-color: #333;
     height: 35px;
 }
+
 .sidebar-separator {
     background-color: #333;
     height: 25px;
 }
+
 .logo-separator {
     background-color: #333;    
     height: 60px;
@@ -73,6 +82,7 @@ body {
   text-align: right;
   padding-left: 10px;
 }
+
 /* Opened submenu icon */
 #sidebar-container .list-group .list-group-item[aria-expanded="true"] .submenu-icon::after {
     content: " \f0da";
@@ -206,3 +216,24 @@ a.close, a.add_form {
     border-bottom: 1px solid #DCDCDC;
     padding-top: 0.75rem;
 }
+
+/* Collapse div */
+.mycollapse {
+    display: block;
+    max-height: 0px;
+    overflow: hidden;
+    transition: max-height .5s cubic-bezier(0, 1, 0, 1);
+}
+
+.mycollapse-block {
+    padding: 5px;
+    margin: 5px 0px;
+    border: 1px solid #DCDCDC;
+}
+
+.myshow {
+    max-height: 99em;
+    transition: max-height .5s ease-in-out;
+}
+/* End collapse div */
+

--- a/main/staticfiles/js/create_crawler.js
+++ b/main/staticfiles/js/create_crawler.js
@@ -1,3 +1,21 @@
+/* Collapse div */
+
+function mycollapse(target){
+    console.log(target);
+    var el = $(target);
+    console.log(el.text());
+    if(el.hasClass("myshow")){
+        el.removeClass("myshow");
+        console.log("remove myshow");
+    }
+    else{
+        el.addClass("myshow");
+        console.log("add myshow");
+    }
+}
+
+/* End collapse div */
+
 function enableCreateButton() {
     var blocks = document.getElementsByClassName('valid-icon');
     var isValid = true;
@@ -243,8 +261,9 @@ function checkRelatedFields() {
 
 $(document).ready(function () {
     setNavigation();
-
     $('input').on('blur keyup', checkRelatedFields);
+    $('#collapse-adv-links').on("click", function () { mycollapse("#adv-links");})
+    $('#collapse-adv-download').on("click", function () { mycollapse("#adv-download"); })
 });
 
 function showBlock(clicked_id) {
@@ -298,7 +317,6 @@ function detailBaseUrl() {
 
     checkTemplatedURL();
 }
-
 
 function detailWebdriverType() {
     setHiddenState("webdriver_path_div", !getCheckboxState("id_has_webdriver"));
@@ -436,7 +454,6 @@ function detailCrawlerType() {
 function autothrottleEnabled() {
     setHiddenState("autothrottle-options-div", !getCheckboxState("id_antiblock_autothrottle_enabled"));
 }
-
 
 const table_input = document.querySelectorAll(".dynamic_input_table")
 

--- a/main/templates/main/create_crawler.html
+++ b/main/templates/main/create_crawler.html
@@ -253,20 +253,66 @@ New Crawler
                         <div class="row" style="padding:20px;">
                             <div class="col md-6">
                                 {{ form.crawler_type | as_crispy_field}}
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <div class="col md-6">
                                 <div class="crawler-type-content-div" id="static_page">
                                     <div id="explore_links" style="padding: 20px; border-top: 1px solid #DCDCDC;">
                                         {{ form.explore_links | as_crispy_field}}
                                         {{ form.link_extractor_max_depth | as_crispy_field}}
                                         {{ form.link_extractor_allow_url | as_crispy_field}}
+
+                                        <div class="btn btn-primary" id="collapse-adv-links">
+                                            Opções Avançadas
+                                        </div>
+                                        <div class="mycollapse" id="adv-links">
+                                            <div class="mycollapse-block">
+                                                {{ form.link_extractor_allow_domains | as_crispy_field }}
+                                                {{ form.link_extractor_tags | as_crispy_field }}
+                                                {{ form.link_extractor_attrs | as_crispy_field }}
+                                                {{ form.link_extractor_check_type | as_crispy_field }}
+                                                <p>Se existirem urls que apontam para arquivos mas não <strong>terminam</strong>
+                                                    em uma extensão de arquivo, o coletor pode conferir o tipo da página pra qual a url aponta.
+                                                    Nesse caso, ele irá requisitar os <i>headers</i> da url. Se o tipo for <i>'text/html'</i>,
+                                                    a página será tratada com um html; caso contrário, como um arquivo. Habilitar essa opção
+                                                    pode deixar a coleta mais lenta, então priorize filtrar urls com regex.
+                                                </p>
+                                                {{ form.link_extractor_process_value | as_crispy_field }}
+                                            </div>
+                                        </div>
                                     </div>
+
                                     <div id="download_files" style="padding: 20px; border-top: 1px solid #DCDCDC;">
                                         {{ form.download_files | as_crispy_field}}
                                         {{ form.download_files_allow_url | as_crispy_field}}
                                         {{ form.download_files_allow_extensions | as_crispy_field}}
+
+                                        <div class="btn btn-primary" id="collapse-adv-download">
+                                            Opções Avançadas
+                                        </div>
+                                        <div class="mycollapse" id="adv-download">
+                                            <div class="mycollapse-block">
+                                                {{ form.download_files_allow_domains | as_crispy_field }}
+                                                {{ form.download_files_tags | as_crispy_field }}
+                                                {{ form.download_files_attrs | as_crispy_field }}
+                                                {{ form.download_files_check_type | as_crispy_field }}
+                                                <p>Se existirem urls que apontam para arquivos mas não <strong>terminam</strong>
+                                                    em uma extensão de arquivo, o coletor pode conferir o tipo da página pra qual a url aponta.
+                                                    Nesse caso, ele irá requisitar os <i>headers</i> da url. Se o tipo for <i>'text/html'</i>,
+                                                    a página será tratada com um html; caso contrário, como um arquivo. Habilitar essa opção
+                                                    pode deixar a coleta mais lenta, então priorize filtrar urls com regex.
+                                                </p>
+                                                {{ form.download_files_process_value | as_crispy_field }}
+                                            </div>
+                                        </div>
                                     </div>
+
                                     <div id="download_img" style="padding:20px; border-top: 1px solid #DCDCDC;">
                                         {{ form.download_imgs | as_crispy_field}}
                                     </div>
+
                                     <div id="wait_crawler_finish_to_download" style="padding:20px; border-top: 1px solid #DCDCDC;">
                                         <p>
                                             Alguns servidores podem cancelar o download se outras requisições forem feitas ao mesmo tempo,
@@ -277,15 +323,21 @@ New Crawler
                                         {{ form.wait_crawler_finish_to_download | as_crispy_field }}
                                         {{ form.time_between_downloads | as_crispy_field }}
                                     </div>
+
                                 </div>
-                                <div class="crawler-type-content-div" id="form_page" hidden>
-                                    {{ form.steps |  as_crispy_field }}
-                                </div>
-                                <div class="crawler-type-content-div" id="single_file" hidden></div>
-                                <div class="crawler-type-content-div" id="bundle_file" hidden></div>
                             </div>
                         </div>
+
+                        <div class="row">
+                            <div class="col md-6">
+                                <div class="crawler-type-content-div" id="form_page" hidden>
+                                    {{ form.steps |  as_crispy_field }}
+                                </div>      
+                            </div>
+                        </div>
+
                     </div>
+
                     <div id="templated-url-item-block" class="block" hidden>
                         <div class="row">
                             <div class="col md-6" id="templated-url-config">
@@ -293,6 +345,7 @@ New Crawler
                             </div>
                         </div>
                     </div>
+
                     <div id="parsing-item-block" class="block" hidden>
                         <div class="row" style="padding:20px;">
                             <div class="col md-6">


### PR DESCRIPTION
Adicionei opções avançadas para configuração dessas funcionalidades, que ficam escondidas sobre um botão "Opções Avançadas". Elas são: 
- Permitir só urls dos domínios: (em branco para não filtrar)
Pros casos onde é mais fácil listar os domínios do que usar regex.  
- Extrair links de tags do tipo: (separado por vírgula)
- Extrair urls dos atributos: (separado por vírgula)
- Função python para processar os atributos: (A função será chamada como 'eval(func)(attr)')
Essas três são para casos estranhos como o que vou deixar de exemplo. Os links estavam dentro de tags a, mas no atributo onclick e precisavam de um processamento especial para extrair:
``<a class="wpdm-download-link btn btn-primary " rel="nofollow" href="#" onclick="location.href='http://www.olaria.mg.gov.br/download/download-anexos-4/?wpdmdl=1686';return false;" data-wahfont="11">Download</a>``
- Checar tipo da página
Nem sempre é necessário fazer a checagem do tipo. Quando as urls são bem definidas, checar o tipo de cada url descoberta só deixa o processo lento. Então adicionei uma opção para desabilitar.

As configurações são bem avançadas mesmo pois tive que fazer vários testes até chegar na função de tratamento adequada, pois o LinkExtractor estava adicionando prefixos desnecessários às urls descobertas por algum motivo.

Adicionei um tratamento a função de conversão de binários do file_downloader para que ele só tente extrair de pdfs, já que é o único caso que funciona mesmo.

Segue o exemplo de configuração de um coletor. Deixei só os valores que alterei.
```
{
  "source_name": "Licitacao - Prefeitura de Olaria",
  "base_url": "http://www.olaria.mg.gov.br/processos-liciatorios/",
  "obey_robots": true,
  "data_path": "coletas/olaria",
  "request_type": "GET",
  "link_extractor_max_depth": 5,
  "link_extractor_allow_url": "^http\\:\\/\\/www\\.olaria\\.mg\\.gov\\.br\\/",
  "download_files": true,
  "download_files_allow_url": "^http\\:\\/\\/www\\.olaria\\.mg\\.gov\\.br\\/",
  "download_files_allow_extensions": "pdf,zip,csv,xml,doc,docx,xls,xlsx",
  "download_files_attrs": "href,onclick",
  "download_files_check_type": true,
  "download_files_process_value": "lambda url: url.split(\"'\")[1].replace(\"www.olaria.mg.gov.br/\", \"\") if \"location\" in url else url",
   (...)
}
```

close #335 