### PR TITLE
Issue 345 - Bug no script em configurações avançadas

### DIFF
--- a/crawlers/static_page.py
+++ b/crawlers/static_page.py
@@ -147,7 +147,7 @@ class StaticPageSpider(BaseSpider):
         config = self.convert_allow_extesions(config)
 
         attr = "download_files_process_value"
-        if config[attr] is not None and type(config[attr]) is str:
+        if config[attr] is not None and len(config[attr]) > 0 and type(config[attr]) is str:
             config[attr] = eval(config[attr])
 
         config["download_files_processed"] = True


### PR DESCRIPTION
Nas configurações avançadas, há um campo em que pode-se definir um script para processamento específico das URLs. Quando um coletor é criado com esse campo em branco, ocorre um erro.

Foi adicionada uma condição para checar se o campo do script está vazio.

Close #345 