### PR TITLE
Issue 344 - Faltando "/" em alguns paths

### DIFF
--- a/crawlers/base_spider.py
+++ b/crawlers/base_spider.py
@@ -381,7 +381,7 @@ class BaseSpider(scrapy.Spider):
             description["extracted_from"] = description["relative_path"]
             description["relative_path"] = output_filename
             description["type"] = "csv"
-            self.feed_file_description(f"{self.data_folder}csv/", description)
+            self.feed_file_description(f"{self.data_folder}/csv/", description)
             return [output_filename]
 
         return []
@@ -420,7 +420,7 @@ class BaseSpider(scrapy.Spider):
         description["extracted_files"] = extracted_files
 
         self.feed_file_description(
-            self.data_folder + "raw_pages", description)
+            self.data_folder + "/raw_pages", description)
 
     def errback_httpbin(self, failure):
         # log all errback failures,


### PR DESCRIPTION
Na Base Spider, há dois paths em que a barra está faltante entre um diretório e outro. Isso gera um caminho que não existe e, consequentemente, um eventual erro.

Close #344 