### PR TITLE
Issue 343 - Wget dando problema com caracteres non ASCII nos PDFs

### DIFF
--- a/crawlers/static_page.py
+++ b/crawlers/static_page.py
@@ -229,7 +229,6 @@ class StaticPageSpider(BaseSpider):
             for file in self.extract_files(response):
                 self.feed_file_downloader(file, response)
 
-        print("download_imgs", self.config["download_imgs"])
         if "download_imgs" in self.config and self.config["download_imgs"]:
             for img_url in self.extract_imgs(response):
                 print("feeding", img_url)

--- a/src/crawling_utils/crawling_utils/crawling_utils.py
+++ b/src/crawling_utils/crawling_utils/crawling_utils.py
@@ -4,7 +4,7 @@ import time
 import hashlib
 import os
 from urllib.parse import urlparse
-import wget
+import requests
 
 
 class StopDownload(Exception):
@@ -13,23 +13,16 @@ class StopDownload(Exception):
 
 
 def file_larger_than_giga(url):
-    """
-    True if file has more than 1e9 bytes.
-    Request a single block from url and check its size.
-    """
-    save = {"url": url}
+    # Mudar user-agent para evitar ser bloqueado por usar a biblioteca requests
+    headers = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.66 Safari/537.36'}
+    
+    # requisição apenas para obter o cabeçalho do conteúdo a ser baixado
+    response = requests.head(url, allow_redirects=True, headers=headers)
 
-    def get_size(current, total, widht=None):
-        save["total_size"] = total
-        raise StopDownload
+    # obtem o tamanho do arquivo e converte para inteiro
+    content_length = int(response.headers['Content-Length'])
 
-    try:
-        wget.download(url, bar=get_size)
-    except StopDownload:
-        pass
-
-    # total_size is in bytes
-    return save["total_size"] > 1e9
+    return content_length > 1e9
 
 
 def get_url_domain(url):


### PR DESCRIPTION
Durante as coletas, alguns arquivos geravam uma exceção por possuir caracteres especiais no nome, como acentos, etc. O @elvesrodrigues sugeriu uma solução que usa requests em vez de wget.

Close #343 